### PR TITLE
docs: add CLAUDE.md with architecture and command reference

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,3 +74,6 @@ frontend/src/dataconnect-generated/
 .claude/
 .agents/
 skills-lock.json
+
+# graphify knowledge-graph output (regenerate with `graphify update .`)
+graphify-out/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,6 +47,15 @@ in the Firebase console, so nothing here enforces them and any new invariant tha
 enforcement has to be applied in the console separately. In-repo, the only authorization checks are
 client-side (`tableData.hostId !== user.uid` and similar in `firestoreApi.ts`).
 
+Two gaps worth knowing about, since nothing in the repo covers them:
+
+- `startGame(tableId)` and `endGame(tableId)` take **no `user` argument and perform no host check
+  at all** — unlike `startNextHand`, `advanceStage`, `kickPlayer`, `addChips`, `confirmWinners` and
+  `transferHost`, which all compare against `hostId`. `endGame` also has no `state` guard, so
+  re-ending a `SUMMARY` table re-increments every player's `stats.sessionsPlayed`.
+- The table `password` is stored **in cleartext on the table doc** and checked client-side in
+  `joinTable`, so any client that can read `tables/{id}` can read it out of the snapshot.
+
 ## Architecture
 
 ### There is no backend
@@ -65,15 +74,25 @@ change one, change the other.
 
 - `tables/{tableId}` — id is a 5-char human-typeable code (`generateShortTableId`, ambiguous chars
   excluded). `state`: `LOBBY` → `IN_GAME` → `SUMMARY`. Holds `hostId`, blinds, `initialStack`,
-  `mode` (`CASH`|`TOURNAMENT`) + `tournamentConfig`, `isVirtualCards`, `currentHandId`, and
-  `lastHandStartedAt`/`gameStartedAt` (bumped only on hand start — the sweeper's idleness signal).
+  `mode` (`CASH`|`TOURNAMENT`) + `tournamentConfig`, `isVirtualCards`, `currentHandId`, `password`
+  (cleartext, see above), `createdAt`, and two timestamps that are easy to confuse:
+  `lastHandStartedAt` is bumped on **every** hand start (the sweeper's idleness signal), while
+  `gameStartedAt` is written **once**, in `startGame`, and never again — `TablePage`'s whole-session
+  elapsed timer reads `gameStartedAt || createdAt`, so bumping it per hand would reset that timer
+  every hand. The sweeper falls back `lastHandStartedAt ?? gameStartedAt ?? createdAt`.
   On `endGame()` the recap (`playerIds[]`, `players[]`) is written **onto the table doc itself**;
   there is no separate history collection. `HomePage` reads history via
   `where("state","==","SUMMARY") + where("playerIds","array-contains",uid)` — the one composite
   index in `firestore.indexes.json`.
 - `tables/{tableId}/players/{uid}` — `stack`, `seatIndex`, `isFolded`, `isSittingOut`, `isAllIn`,
-  `totalBuyIn` (rebuys, for net-profit), `satAt`/`accumulatedTime` (time-played tracking).
-  **Turn order is `seatIndex` ascending, and hand logic indexes players by seat position, not uid.**
+  `totalBuyIn` (rebuys, for net-profit), `satAt`/`accumulatedTime` (time-played tracking), and
+  `hasLeft`/`leftAt`. **Turn order is `seatIndex` ascending, and hand logic indexes players by seat
+  position, not uid.** That is why `quitGame` sets `hasLeft: true` rather than deleting the doc —
+  deleting mid-hand would shift every stored positional index. Host handoff picks the first
+  candidate with `!hasLeft`, so anything that iterates players for a *live* role must filter on it.
+  Note `leaveTable` (lobby-only in practice, wired to the "leave lobby" button) *does* delete the
+  doc, and `joinTable` derives the new `seatIndex` from the player count — so a lobby departure
+  followed by a join produces two players on the same seat.
 - `tables/{tableId}/hands/{handId}` — the `HandData` interface: `stage`, `dealerIndex`/
   `smallBlindIndex`/`bigBlindIndex`/`currentTurnIndex`/`firstToActIndex`/`lastAggressorIndex`,
   `pot`, `currentBet`, `roundBets` (this street), `handContributions` (whole hand — the side-pot
@@ -86,11 +105,12 @@ change one, change the other.
 
 ### Transaction discipline (the main footgun)
 
-Firestore transactions cannot run queries, and every read must precede every write. So each mutating
-API in `firestoreApi.ts` follows the same shape, and new ones should too:
+Firestore transactions cannot run queries, and every read must precede every write. So most mutating
+APIs in `firestoreApi.ts` follow the same shape, and new ones should too:
 
 1. `getDocs(query(players, orderBy("seatIndex")))` **outside** the transaction, purely to learn which
-   doc refs exist (seat order can't change mid-hand).
+   doc refs exist. This assumes seat order can't change mid-hand — an assumption **nothing enforces**:
+   `swapSeats` is a bare `writeBatch` with neither a host check nor a `state !== "IN_GAME"` guard.
 2. Inside `runTransaction`: `transaction.get()` the table, the hand, all player docs — *and* the
    `users/{id}` docs needed for stats (`getStatsCandidateIds()` exists to compute that set before any
    write).
@@ -103,18 +123,33 @@ phases. Adding a read after a write silently breaks the transaction at runtime.
 Operations that can't fit one transaction (e.g. `startNextHand` discovering the tournament is over)
 set a flag and call the follow-up (`endGame()`) after the transaction commits.
 
+Known exceptions to the shape above — don't read them as the pattern:
+
+- `endGame()` is **not transactional at all**: it does `getDoc`/`getDocs` and then commits a
+  `writeBatch`, so two clients ending the same table concurrently both read the pre-end state and
+  both increment `stats.sessionsPlayed`/`stats.timePlayedSeconds`. `scripts/end-stale-tables.mjs`
+  mirrors it, so the same race exists server-side.
+- `endGame()` and `confirmWinners()` call `getDocs(playersRef)` with **no `orderBy`**, so their
+  `playerRefs` are *not* in seat order. Don't index them positionally.
+
 ### Hand lifecycle
 
 `startGame` / `startNextHand` create a hand doc (rotating dealer/SB/BB, heads-up special-cased:
 dealer is SB and acts first preflop) → `playerAction` (`CHECK` | `CALL` | `BET` | `FOLD`; all-in is
 expressed as a `BET` equal to the full stack, or a `CALL` clipped to it — there is no `ALLIN` action)
-→ round closes via `lastAggressorIndex` bookkeeping → `advanceStage`
+→ round closes via `lastAggressorIndex` bookkeeping → `advanceStage` **(host-only)**
 (`PREFLOP`→`FLOP`→`TURN`→`RIVER`→`SHOWDOWN`; post-flop the SB, or the first active player after,
-always acts first) → showdown → `startNextHand` (host-only).
+always acts first) → showdown → `startNextHand` **(host-only)**.
+
+`HomePage` also branches on a `state === "ENDED"`, which nothing in `frontend/src` or `scripts/`
+ever writes — treat it as vestigial, not a fourth state.
 
 Pots: `calculatePotsCore()` derives cascading side pots from `handContributions`; a pot with ≤1
 eligible player auto-settles. `splitPot()` rounds shares down to a multiple of 5 and hands the
-remainder to a random winner — chip totals stay integral and losslessly conserved.
+remainder to a random winner, so chip totals stay integral. **It picks that winner with an internal
+`Math.random()` and is called more than once per settlement** (once to credit stacks, again from
+`getStatsCandidateIds`/`applyStatsUpdates`), so the rolls disagree and recorded stats can diverge
+from the chips actually paid. Compute the split once and thread the result through.
 
 ### Two card modes, one engine
 
@@ -129,10 +164,17 @@ Both paths converge on the same pot/stat writes, so changes to settlement usuall
 
 ### Player stats
 
-`applyStatsUpdates()` runs inside the same transaction that finishes a hand. Note the VPIP
-bookkeeping: `stats.vpipCount` is divided by `stats.vpipEligibleHands`, deliberately **not** by
-`handsPlayed`/`stagePreflopCount`, because those accumulated before VPIP tracking existed and would
-skew the ratio for months. Keep new ratio metrics on their own matched-baseline denominators.
+`applyStatsUpdates()` runs inside the same transaction that finishes a hand, and handles the
+per-hand counters (`handsPlayed`, `handsWon`, `totalChipsWon`/`totalChipsLost`, `netProfit`,
+`bestHandRank`).
+
+VPIP is **not** in there, despite being the stat most likely to be copied as a template. Its two
+counters are incremented in `playerAction`, in the preflop branch, gated on the player's first
+preflop decision — so `stats.vpipEligibleHands` counts decision points, not hands — and the ratio
+itself is computed in `components/AdvancedStats.tsx`. It is divided by `vpipEligibleHands`
+deliberately, **not** by `handsPlayed`/`stagePreflopCount`, because those accumulated before VPIP
+tracking existed and would skew the ratio for months. Keep new ratio metrics on their own
+matched-baseline denominators, and increment them where the event actually happens.
 
 ### Auth
 
@@ -152,10 +194,17 @@ re-render detection fails). Read the comments before refactoring that file.
   whole in-game UI. Confirmations are custom JSX modal blocks (`foldConfirmModalUI`,
   `kickConfirmModalUI`, …) assembled at the bottom of the component — native `confirm()`/`alert()`
   were deliberately removed, so follow that pattern for new prompts.
-- All user-facing text goes through `react-i18next` (`locales/en.json`, `locales/it.json`; add keys to
-  **both**). User-visible errors thrown from `firestoreApi.ts` should be i18n keys — `throw new
+- Almost all user-facing text goes through `react-i18next` (`locales/en.json`, `locales/it.json`; add
+  keys to **both** — the current baseline is 384 vs 383 keys, `it.json` is missing
+  `joinTable.gameInProgressWarning`). The documented exception is `components/ReloadPrompt.tsx`,
+  which branches on `i18n.resolvedLanguage === 'it'` and inlines both translations, so its strings
+  are invisible to anyone grepping the locale files.
+- User-visible errors thrown from `firestoreApi.ts` should be i18n keys — `throw new
   Error("error.onlyHost")` — because `TablePage` renders them as `t(actionError)`. Older code throws
-  raw Italian strings, which pass through `t()` unchanged; prefer keys for anything new.
+  raw Italian strings. Those pass through `t()` unchanged **only if they contain no colon**:
+  `i18n.ts` doesn't set `nsSeparator: false`, so i18next reads the text before a `:` as a namespace
+  and renders only what follows it, silently truncating the message. Several existing throws are
+  already truncated this way. Use keys for anything new.
 - Comments and internal error text are mixed Italian/English (Italian dominates the older code).
   Match the surrounding file.
 
@@ -172,3 +221,7 @@ cache headers to those two.
 `dataconnect/` and `frontend/src/dataconnect-generated/` are gitignored and unused — nothing imports
 `@dataconnect/generated` despite the package.json entry. Root `dist/` is a stale gh-pages leftover;
 the deployed output is `frontend/dist`.
+
+`frontend/src/index.css` and `frontend/src/App.css` are orphans — `main.tsx` imports only
+`./styles/index.css`, and the reset in `src/index.css` is duplicated inside it. Editing the
+conventional-looking `src/index.css` has no effect on the app and produces no error.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,174 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Commands
+
+All frontend work happens in `frontend/`:
+
+```bash
+cd frontend
+npm install
+npm run dev        # Vite dev server on 0.0.0.0:5173 (host exposed for phone testing over LAN/ngrok)
+npm run build      # tsc -b && vite build  -> frontend/dist
+npx tsc -b         # type-check only (much faster than a full build)
+npm run lint       # eslint flat config (typescript-eslint + react-hooks + react-refresh)
+```
+
+`npm run dev` and `npm run build` require `frontend/.env` (gitignored) with the six
+`VITE_FIREBASE_*` keys — the same names CI injects from repo secrets. Without it the app boots
+into a Firebase init error.
+
+`npx tsc -b` is the real gate and passes clean; **`npm run lint` does not** — `main` currently
+carries ~134 pre-existing errors (122 of them `@typescript-eslint/no-explicit-any`, since Firestore
+snapshot data is read as `any` throughout). Nothing in CI runs it. Compare against the baseline
+rather than treating a non-zero exit as your own regression.
+
+There is **no test suite and no test runner**, and `firebase.json` configures no Auth/Firestore
+emulators. Changes are verified by running the dev server against the real `airpoker-84425`
+project, so prefer creating a throwaway table over touching existing data.
+
+Maintenance script (standalone, not part of the frontend build):
+
+```bash
+cd scripts && npm install
+DRY_RUN=1 npm run end-stale-tables   # needs FIRESTORE_SWEEPER_KEY (inline SA JSON) or GOOGLE_APPLICATION_CREDENTIALS
+```
+
+### Deploys
+
+Pushes to `main` build and deploy to Firebase Hosting live channel automatically
+(`.github/workflows/firebase-hosting-merge.yml`); PRs get preview channels. Manual equivalents:
+`npx firebase deploy --only hosting` (public dir is `frontend/dist`) and
+`npx firebase deploy --only firestore:indexes`.
+
+**Firestore security rules are not in this repo** — `firebase.json` declares only indexes. Rules live
+in the Firebase console, so nothing here enforces them and any new invariant that needs rule-level
+enforcement has to be applied in the console separately. In-repo, the only authorization checks are
+client-side (`tableData.hostId !== user.uid` and similar in `firestoreApi.ts`).
+
+## Architecture
+
+### There is no backend
+
+Despite what `README.md` says, there are no Cloud Functions. Dealing, betting, side-pot math,
+showdown evaluation and player-stat aggregation all run **in the browser**, inside Firestore
+transactions, from `frontend/src/lib/firestoreApi.ts` (~2.5k lines — the heart of the app).
+Clients converge purely through `onSnapshot` listeners on shared documents.
+
+The only server-side code is `scripts/end-stale-tables.mjs`, a GitHub Actions cron job
+(every 30 min) that force-ends tables stuck `IN_GAME` with no new hand for 3h. It intentionally
+**duplicates `endGame()`'s logic** in `firebase-admin` JS so recaps look identical either way —
+change one, change the other.
+
+### Firestore data model
+
+- `tables/{tableId}` — id is a 5-char human-typeable code (`generateShortTableId`, ambiguous chars
+  excluded). `state`: `LOBBY` → `IN_GAME` → `SUMMARY`. Holds `hostId`, blinds, `initialStack`,
+  `mode` (`CASH`|`TOURNAMENT`) + `tournamentConfig`, `isVirtualCards`, `currentHandId`, and
+  `lastHandStartedAt`/`gameStartedAt` (bumped only on hand start — the sweeper's idleness signal).
+  On `endGame()` the recap (`playerIds[]`, `players[]`) is written **onto the table doc itself**;
+  there is no separate history collection. `HomePage` reads history via
+  `where("state","==","SUMMARY") + where("playerIds","array-contains",uid)` — the one composite
+  index in `firestore.indexes.json`.
+- `tables/{tableId}/players/{uid}` — `stack`, `seatIndex`, `isFolded`, `isSittingOut`, `isAllIn`,
+  `totalBuyIn` (rebuys, for net-profit), `satAt`/`accumulatedTime` (time-played tracking).
+  **Turn order is `seatIndex` ascending, and hand logic indexes players by seat position, not uid.**
+- `tables/{tableId}/hands/{handId}` — the `HandData` interface: `stage`, `dealerIndex`/
+  `smallBlindIndex`/`bigBlindIndex`/`currentTurnIndex`/`firstToActIndex`/`lastAggressorIndex`,
+  `pot`, `currentBet`, `roundBets` (this street), `handContributions` (whole hand — the side-pot
+  input), `pots[]`, `votingOpen`, `winnerIds`, plus virtual-mode `communityCards`, `playerHands`,
+  `handResults`.
+- `users/{uid}` — created for guests too (so every seat resolves to a profile). `username` /
+  `usernameLowercase` (uniqueness enforced by a query in `useAuth.tsx`, **not** by rules),
+  `isRegistered`, `photoURL`, `presence.{status,location,tableId,lastActive}` (heartbeat written by
+  `HomePage`/`TablePage`), and `stats.*` counters. Subcollections: `friends`, `invitations`.
+
+### Transaction discipline (the main footgun)
+
+Firestore transactions cannot run queries, and every read must precede every write. So each mutating
+API in `firestoreApi.ts` follows the same shape, and new ones should too:
+
+1. `getDocs(query(players, orderBy("seatIndex")))` **outside** the transaction, purely to learn which
+   doc refs exist (seat order can't change mid-hand).
+2. Inside `runTransaction`: `transaction.get()` the table, the hand, all player docs — *and* the
+   `users/{id}` docs needed for stats (`getStatsCandidateIds()` exists to compute that set before any
+   write).
+3. Pure in-memory computation.
+4. All `transaction.update()` calls last.
+
+Functions are commented with `===== LETTURA =====` / `===== SCRITTURA =====` markers delimiting these
+phases. Adding a read after a write silently breaks the transaction at runtime.
+
+Operations that can't fit one transaction (e.g. `startNextHand` discovering the tournament is over)
+set a flag and call the follow-up (`endGame()`) after the transaction commits.
+
+### Hand lifecycle
+
+`startGame` / `startNextHand` create a hand doc (rotating dealer/SB/BB, heads-up special-cased:
+dealer is SB and acts first preflop) → `playerAction` (`CHECK` | `CALL` | `BET` | `FOLD`; all-in is
+expressed as a `BET` equal to the full stack, or a `CALL` clipped to it — there is no `ALLIN` action)
+→ round closes via `lastAggressorIndex` bookkeeping → `advanceStage`
+(`PREFLOP`→`FLOP`→`TURN`→`RIVER`→`SHOWDOWN`; post-flop the SB, or the first active player after,
+always acts first) → showdown → `startNextHand` (host-only).
+
+Pots: `calculatePotsCore()` derives cascading side pots from `handContributions`; a pot with ≤1
+eligible player auto-settles. `splitPot()` rounds shares down to a multiple of 5 and hands the
+remainder to a random winner — chip totals stay integral and losslessly conserved.
+
+### Two card modes, one engine
+
+- **Virtual** (`isVirtualCards`): the deck is shuffled and the *entire* board (with burn cards) plus
+  all hole cards are dealt up-front into the hand doc at creation. Showdown is settled automatically
+  by `autoEvaluateShowdown()` + `determineWinners()` from `lib/pokerEvaluator.ts` (brute-forces all
+  C(7,5) combos into comparable score arrays; ties split).
+- **Physical**: the app tracks money only. At showdown `votingOpen` is set and the host resolves each
+  unsettled pot with `confirmWinners(tableId, user, winnerIds, potId)`.
+
+Both paths converge on the same pot/stat writes, so changes to settlement usually need to touch both.
+
+### Player stats
+
+`applyStatsUpdates()` runs inside the same transaction that finishes a hand. Note the VPIP
+bookkeeping: `stats.vpipCount` is divided by `stats.vpipEligibleHands`, deliberately **not** by
+`handsPlayed`/`stagePreflopCount`, because those accumulated before VPIP tracking existed and would
+skew the ratio for months. Keep new ratio metrics on their own matched-baseline denominators.
+
+### Auth
+
+`hooks/useAuth.tsx` is the single source of truth: anonymous guests (nickname only), email/password,
+and Google, plus `linkGuestToRegistered()` which upgrades a guest **in place** (uid preserved, so an
+in-progress table session survives). Several non-obvious workarounds in there are commented — the
+`isRegisteringRef` mirror (the `onAuthStateChanged` subscription must not resubscribe), and tracking
+`linkedProviderIds` as separate state (Firebase mutates the `User` object in place, so identity-based
+re-render detection fails). Read the comments before refactoring that file.
+
+### UI conventions
+
+- **No Tailwind** (the README is wrong). Styling is `frontend/src/styles/index.css` (~1.9k lines) with
+  CSS custom properties (`--color-primary`, `--text-muted`, …) and utility-ish classes
+  (`.glass-panel`, `.poker-card-3d-*`), supplemented by inline `style` objects.
+- The app is route-heavy rather than component-heavy: `routes/TablePage.tsx` (~3.7k lines) contains the
+  whole in-game UI. Confirmations are custom JSX modal blocks (`foldConfirmModalUI`,
+  `kickConfirmModalUI`, …) assembled at the bottom of the component — native `confirm()`/`alert()`
+  were deliberately removed, so follow that pattern for new prompts.
+- All user-facing text goes through `react-i18next` (`locales/en.json`, `locales/it.json`; add keys to
+  **both**). User-visible errors thrown from `firestoreApi.ts` should be i18n keys — `throw new
+  Error("error.onlyHost")` — because `TablePage` renders them as `t(actionError)`. Older code throws
+  raw Italian strings, which pass through `t()` unchanged; prefer keys for anything new.
+- Comments and internal error text are mixed Italian/English (Italian dominates the older code).
+  Match the surrounding file.
+
+### PWA
+
+`vite-plugin-pwa` with `registerType: 'prompt'`. `components/ReloadPrompt.tsx` actively polls for a new
+service worker (15 min interval, 1 min floor, "Later" snoozes 30 min) because installed sessions run
+for hours with a wake lock held and would otherwise never see a deploy. `firebase.json` pairs with this:
+`index.html` and `/sw.js` are `no-store`, hashed assets are immutable-cached. Don't add long-lived
+cache headers to those two.
+
+### Ignore these
+
+`dataconnect/` and `frontend/src/dataconnect-generated/` are gitignored and unused — nothing imports
+`@dataconnect/generated` despite the package.json entry. Root `dist/` is a stale gh-pages leftover;
+the deployed output is `frontend/dist`.


### PR DESCRIPTION
## Summary

Adds a `CLAUDE.md` at the repo root documenting the things that are not discoverable from the file tree, and ignores the local `graphify-out/` build artifact. Docs and ignore-rules only — **no application code changes** (`.gitignore` + `CLAUDE.md`, +230 lines).

## What the doc records

- **There is no backend.** All dealing, betting, side-pot math, showdown evaluation and stat aggregation run client-side in `frontend/src/lib/firestoreApi.ts`; the only server-side code is the `end-stale-tables` cron.
- **The Firestore data model** — `tables`, `players`, `hands`, `users` — including the easy-to-confuse `lastHandStartedAt` (bumped every hand) vs `gameStartedAt` (written once, backs the session timer).
- **Transaction discipline**, the main footgun: Firestore transactions cannot run queries and every read must precede every write, so mutating APIs follow a fixed 4-phase shape. Adding a read after a write breaks the transaction silently at runtime.
- **Hand lifecycle**, the two card modes (virtual vs physical) that converge on the same settlement path, and where player stats are actually incremented (VPIP is in `playerAction`, not `applyStatsUpdates`).
- **UI/i18n conventions** — no Tailwind, custom modals instead of native `confirm()`, and error strings as i18n keys.

It also corrects two points where `README.md` is out of date (it claims Cloud Functions and TailwindCSS; neither exists) and records the current `npm run lint` baseline so a non-zero exit is not mistaken for a fresh regression.

## Gaps documented along the way

Reviewing the doc against the code surfaced several real divergences. These are **written down, not fixed** — no behavior changes in this PR:

- `startGame`/`endGame` take no `user` argument and perform no host check, unlike every other mutating API. `endGame` also has no `state` guard, so re-ending a `SUMMARY` table re-increments every player's `stats.sessionsPlayed`.
- `endGame()` is not transactional (read-then-`writeBatch`), so two concurrent clients both increment session stats. `scripts/end-stale-tables.mjs` mirrors the same race.
- `splitPot()` picks the odd-chip winner with an internal `Math.random()` but is called more than once per settlement, so recorded stats can diverge from the chips actually paid.
- The table `password` is stored cleartext on the table doc and checked client-side.
- `swapSeats` is a bare `writeBatch` with no host check and no `IN_GAME` guard, though the seat-order invariant depends on it.

Worth follow-up issues; called out here so the next reader does not rediscover them.

## Test plan

Documentation only — nothing to run. The `.gitignore` change was verified with `git check-ignore graphify-out/graph.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
