### PR TITLE
fix: require host identity to start and end a game

### DIFF
--- a/frontend/src/lib/firestoreApi.ts
+++ b/frontend/src/lib/firestoreApi.ts
@@ -591,7 +591,7 @@ export async function swapPlayerSeats(
  * - Con 2 giocatori (heads-up): giocatore 0 = BB, giocatore 1 = SB/Dealer
  * - Con 3+ giocatori: giocatore 0 = Dealer, 1 = SB, 2 = BB
  */
-export async function startGame(tableId: string) {
+export async function startGame(tableId: string, user: User) {
   const tableRef = doc(db, "tables", tableId);
 
   const playersRef = collection(db, "tables", tableId, "players");
@@ -606,6 +606,10 @@ export async function startGame(tableId: string) {
     }
 
     const tableData = tableSnap.data() as any;
+
+    if (tableData.hostId !== user.uid) {
+      throw new Error("error.onlyHost");
+    }
 
     if (tableData.state !== "LOBBY") {
       throw new Error("La partita è già iniziata o il tavolo non è in LOBBY");
@@ -1127,11 +1131,21 @@ export async function forceFoldPlayer(
   });
 }
 
-export async function endGame(tableId: string) {
+export async function endGame(tableId: string, user: User) {
   const tableRef = doc(db, "tables", tableId);
   const tableSnap = await getDoc(tableRef);
-  if (!tableSnap.exists()) throw new Error("Tavolo inesistente.");
+  if (!tableSnap.exists()) throw new Error("error.tableNotFound");
   const tableData = tableSnap.data() as any;
+
+  if (tableData.hostId !== user.uid) {
+    throw new Error("error.onlyHost");
+  }
+
+  // Senza questo guard, ri-terminare un tavolo già in SUMMARY ri-incrementa
+  // stats.sessionsPlayed e stats.timePlayedSeconds di ogni giocatore.
+  if (tableData.state === "SUMMARY") {
+    throw new Error("error.gameAlreadyEnded");
+  }
 
   const playersSnap = await getDocs(collection(db, "tables", tableId, "players"));
   const userSnaps: Record<string, any> = {};
@@ -1437,7 +1451,7 @@ export async function startNextHand(tableId: string, user: User) {
   });
 
   if (shouldEndTournament) {
-    await endGame(tableId);
+    await endGame(tableId, user);
   }
 }
 

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -218,6 +218,7 @@
     "minPlayers": "At least 2 active players are required for a new hand.",
     "minPlayersStart": "At least 2 active players are required to start.",
     "onlyHost": "Only the host can perform this action.",
+    "gameAlreadyEnded": "This game has already ended.",
     "notInGame": "The table is not in a game state.",
     "tableNotFound": "Table not found.",
     "noPrevHand": "No previous hand found.",

--- a/frontend/src/locales/it.json
+++ b/frontend/src/locales/it.json
@@ -217,6 +217,7 @@
     "minPlayers": "Servono almeno 2 giocatori attivi per una nuova mano.",
     "minPlayersStart": "Servono almeno 2 giocatori attivi per iniziare.",
     "onlyHost": "Solo l'host può eseguire questa azione.",
+    "gameAlreadyEnded": "Questa partita è già terminata.",
     "notInGame": "Il tavolo non è in stato di gioco.",
     "tableNotFound": "Tavolo inesistente.",
     "noPrevHand": "Nessuna mano precedente trovata.",

--- a/frontend/src/routes/TablePage.tsx
+++ b/frontend/src/routes/TablePage.tsx
@@ -1115,8 +1115,9 @@ export default function TablePage() {
   async function handleStartGame() {
     if (!isHost) return;
     if (!tableId) return;
+    if (!user) return;
     try {
-      await startGame(tableId);
+      await startGame(tableId, user);
     } catch (err) {
       console.error("Errore startGame:", err);
     }
@@ -1259,10 +1260,10 @@ async function handleEndGame() {
 }
 
 async function confirmEndGameAction() {
-  if (!isHost || !tableId) return;
+  if (!isHost || !tableId || !user) return;
   try {
     setShowEndGameConfirm(false);
-    await endGame(tableId);
+    await endGame(tableId, user);
   } catch (err) {
     console.error(err);
   }


### PR DESCRIPTION
## Summary

`startGame` and `endGame` were the only mutating APIs in `frontend/src/lib/firestoreApi.ts` that took **no `user` argument and performed no `hostId` comparison**. Every comparable API — `startNextHand`, `advanceStage`, `kickPlayer`, `addChips`, `confirmWinners`, `transferHost` — already checks.

The UI hid both buttons behind `isHost`, but since all game logic runs client-side (there is no backend, and Firestore rules are managed outside this repo), that check was the *only* thing standing between any seated player and starting or ending someone else's table.

Both now take `user: User` and throw `error.onlyHost` on mismatch.

## The stat-corruption bug

`endGame` additionally had **no state guard**. Ending a table already in `SUMMARY` re-ran the entire recap `writeBatch` and re-incremented every player's `stats.sessionsPlayed` and `stats.timePlayedSeconds` — permanently inflating lifetime stats, once per extra call.

It now rejects a table already in `SUMMARY` with a new `error.gameAlreadyEnded` key, added to **both** `en.json` and `it.json`.

## Call sites threaded through

- `routes/TablePage.tsx` — `handleStartGame` and `confirmEndGameAction`, both with `!user` early-returns added.
- `startNextHand`'s tournament-over path (`firestoreApi.ts:1454`) passes its own **already host-checked** `user`, so that flow is unaffected.

`scripts/end-stale-tables.mjs` deliberately duplicates `endGame()`'s logic and is normally kept in sync — but it needs **no mirror change here**: it runs under `firebase-admin` (so a host check is neither possible nor meaningful) and it already sweeps only `IN_GAME` tables, which is exactly the guard being added.

Also swaps `endGame`'s raw `"Tavolo inesistente."` throw for the existing `error.tableNotFound` key, per the i18n-key convention — raw strings are rendered through `t()` and silently truncate at a colon.

## Test plan

This repo has no test suite or emulators, so verification is the type-checker plus the documented baselines:

- `npx tsc -b` — passes clean, exit 0.
- `npx eslint .` — holds at exactly **134 errors**, the documented pre-existing baseline. No new lint debt.
- Locale key counts move together: **385 / 384**, preserving the known one-key gap (`joinTable.gameInProgressWarning`) rather than widening it.

Manual check worth doing against a throwaway table before merge:

1. Host starts a game — works as before.
2. Non-host calls `startGame`/`endGame` directly — rejected with "Only the host can perform this action."
3. End a game, then trigger `endGame` again on the `SUMMARY` table — rejected, and `stats.sessionsPlayed` increments exactly once.
4. Play a tournament down to one player so `startNextHand` auto-ends it — still ends cleanly.

## Follow-up

#9 adds a `CLAUDE.md` that documents both of these as *known gaps*. Once both PRs land, that section is stale and needs a correcting commit on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
