### PR TITLE
fix: guard seat reordering against mid-hand swaps

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,8 +50,8 @@ client-side (`tableData.hostId !== user.uid` and similar in `firestoreApi.ts`).
 Every mutating API in `firestoreApi.ts` now takes a `user` and compares it against `hostId` —
 `startGame` and `endGame` were the last two without one, and gained the check (plus a `SUMMARY`
 guard on `endGame`) alongside `startNextHand`, `advanceStage`, `kickPlayer`, `addChips`,
-`confirmWinners` and `transferHost`. **`swapSeats` is still the exception**: a bare `writeBatch`
-with neither a host check nor a `state !== "IN_GAME"` guard.
+`confirmWinners`, `transferHost` and `swapPlayerSeats`. There is no longer an unguarded mutating
+API — `swapSeats`, the last one, was deleted as a duplicate of `swapPlayerSeats`.
 
 Because these checks are client-side, they constrain the app's own code paths, not a hand-crafted
 SDK call against the same project. Anything that must actually hold has to be enforced in the
@@ -115,8 +115,11 @@ Firestore transactions cannot run queries, and every read must precede every wri
 APIs in `firestoreApi.ts` follow the same shape, and new ones should too:
 
 1. `getDocs(query(players, orderBy("seatIndex")))` **outside** the transaction, purely to learn which
-   doc refs exist. This assumes seat order can't change mid-hand — an assumption **nothing enforces**:
-   `swapSeats` is a bare `writeBatch` with neither a host check nor a `state !== "IN_GAME"` guard.
+   doc refs exist. This assumes seat order can't change mid-hand. `swapPlayerSeats` — the only writer
+   of `seatIndex` on an existing player — now enforces that: it is transactional and rejects a swap
+   unless the current hand is over (`SHOWDOWN` with a winner assigned), mirroring the UI's
+   `disableEndGame`. Reordering *between* hands is a supported feature, so the guard is "no live
+   hand", not "LOBBY only".
 2. Inside `runTransaction`: `transaction.get()` the table, the hand, all player docs — *and* the
    `users/{id}` docs needed for stats (`getStatsCandidateIds()` exists to compute that set before any
    write).
@@ -204,7 +207,7 @@ re-render detection fails). Read the comments before refactoring that file.
   `kickConfirmModalUI`, …) assembled at the bottom of the component — native `confirm()`/`alert()`
   were deliberately removed, so follow that pattern for new prompts.
 - Almost all user-facing text goes through `react-i18next` (`locales/en.json`, `locales/it.json`; add
-  keys to **both** — the current baseline is 385 vs 384 keys, `it.json` is missing
+  keys to **both** — the current baseline is 387 vs 386 keys, `it.json` is missing
   `joinTable.gameInProgressWarning`). The documented exception is `components/ReloadPrompt.tsx`,
   which branches on `i18n.resolvedLanguage === 'it'` and inlines both translations, so its strings
   are invisible to anyone grepping the locale files.

--- a/frontend/src/lib/firestoreApi.ts
+++ b/frontend/src/lib/firestoreApi.ts
@@ -552,6 +552,17 @@ export async function addChips(
 
 /**
  * Host: riordina i giocatori scambiando i seatIndex di due posti.
+ *
+ * L'ordine dei posti è un invariante del motore di gioco: la logica delle mani
+ * indicizza i giocatori per posizione, non per uid, quindi scambiare i seatIndex
+ * mentre una mano è viva sposta dealer/SB/BB e i turni sotto i piedi della mano
+ * in corso. Il guard qui sotto rispecchia `disableEndGame` lato UI: riordinare è
+ * lecito in LOBBY, in SUMMARY e *tra* una mano e l'altra (showdown con vincitore
+ * già assegnato), mai a mano viva.
+ *
+ * Sta dentro una transazione proprio per quel guard: con il vecchio
+ * read-then-writeBatch, una mano che parte tra la lettura e il commit avrebbe
+ * lasciato passare lo scambio comunque.
  */
 export async function swapPlayerSeats(
   tableId: string,
@@ -560,24 +571,41 @@ export async function swapPlayerSeats(
   userIdB: string
 ) {
   const tableRef = doc(db, "tables", tableId);
-  const tableSnap = await getDoc(tableRef);
-  if (!tableSnap.exists()) throw new Error("Tavolo inesistente");
-  const tableData = tableSnap.data() as any;
-  if (tableData.hostId !== host.uid) throw new Error("Solo l'host può riordinare i giocatori");
-
   const refA = doc(db, "tables", tableId, "players", userIdA);
   const refB = doc(db, "tables", tableId, "players", userIdB);
-  const [snapA, snapB] = await Promise.all([getDoc(refA), getDoc(refB)]);
 
-  if (!snapA.exists() || !snapB.exists()) throw new Error("Uno dei giocatori non esiste");
+  await runTransaction(db, async (transaction) => {
+    // ===== LETTURA =====
+    const tableSnap = await transaction.get(tableRef);
+    if (!tableSnap.exists()) throw new Error("error.tableNotFound");
+    const tableData = tableSnap.data() as any;
 
-  const seatA = (snapA.data() as any).seatIndex;
-  const seatB = (snapB.data() as any).seatIndex;
+    if (tableData.hostId !== host.uid) throw new Error("error.onlyHost");
 
-  const batch = writeBatch(db);
-  batch.update(refA, { seatIndex: seatB });
-  batch.update(refB, { seatIndex: seatA });
-  await batch.commit();
+    if (tableData.state === "IN_GAME" && tableData.currentHandId) {
+      const handRef = doc(db, "tables", tableId, "hands", tableData.currentHandId);
+      const handSnap = await transaction.get(handRef);
+      if (handSnap.exists()) {
+        const handData = handSnap.data();
+        const handOver =
+          handData.stage === "SHOWDOWN" &&
+          (!!handData.winnerId ||
+            (Array.isArray(handData.winnerIds) && handData.winnerIds.length > 0));
+        if (!handOver) throw new Error("error.seatChangeDuringHand");
+      }
+    }
+
+    const snapA = await transaction.get(refA);
+    const snapB = await transaction.get(refB);
+    if (!snapA.exists() || !snapB.exists()) throw new Error("error.playerNotFound");
+
+    const seatA = (snapA.data() as any).seatIndex;
+    const seatB = (snapB.data() as any).seatIndex;
+
+    // ===== SCRITTURA =====
+    transaction.update(refA, { seatIndex: seatB });
+    transaction.update(refB, { seatIndex: seatA });
+  });
 }
 
 /**
@@ -792,25 +820,9 @@ export async function startGame(tableId: string, user: User) {
 }
 
 
-/**
- * Scambia i seatIndex di due giocatori (usato dall'host per riordinare).
- */
-export async function swapSeats(
-  tableId: string,
-  playerAId: string,
-  playerBId: string,
-  seatA: number,
-  seatB: number
-) {
-  const playerARef = doc(db, "tables", tableId, "players", playerAId);
-  const playerBRef = doc(db, "tables", tableId, "players", playerBId);
-
-  const batch = writeBatch(db);
-  batch.update(playerARef, { seatIndex: seatB });
-  batch.update(playerBRef, { seatIndex: seatA });
-
-  await batch.commit();
-}
+// swapSeats() è stato rimosso: duplicava swapPlayerSeats() senza host check né
+// guard di stato, e si fidava dei seatIndex passati dal chiamante invece di
+// rileggerli. Usare swapPlayerSeats().
 
 export async function setSittingOut(
   tableId: string,

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -219,8 +219,10 @@
     "minPlayersStart": "At least 2 active players are required to start.",
     "onlyHost": "Only the host can perform this action.",
     "gameAlreadyEnded": "This game has already ended.",
+    "seatChangeDuringHand": "Seats cannot be reordered while a hand is in progress.",
     "notInGame": "The table is not in a game state.",
     "tableNotFound": "Table not found.",
+    "playerNotFound": "Player not found.",
     "noPrevHand": "No previous hand found.",
     "prevHandNotFound": "Previous hand not found.",
     "notShowdown": "The current hand has not finished yet."

--- a/frontend/src/locales/it.json
+++ b/frontend/src/locales/it.json
@@ -218,8 +218,10 @@
     "minPlayersStart": "Servono almeno 2 giocatori attivi per iniziare.",
     "onlyHost": "Solo l'host può eseguire questa azione.",
     "gameAlreadyEnded": "Questa partita è già terminata.",
+    "seatChangeDuringHand": "Non puoi riordinare i posti mentre una mano è in corso.",
     "notInGame": "Il tavolo non è in stato di gioco.",
     "tableNotFound": "Tavolo inesistente.",
+    "playerNotFound": "Giocatore non trovato.",
     "noPrevHand": "Nessuna mano precedente trovata.",
     "prevHandNotFound": "Mano precedente non trovata.",
     "notShowdown": "La mano corrente non è ancora conclusa."

--- a/frontend/src/routes/TablePage.tsx
+++ b/frontend/src/routes/TablePage.tsx
@@ -19,7 +19,6 @@ import { useWakeLock } from "../hooks/useWakeLock";
 import {
   setPlayerReady,
   startGame,
-  swapSeats,
   type HandData,
   playerAction,
   leaveTable,
@@ -1127,38 +1126,36 @@ export default function TablePage() {
     if (!isHost) return;
     if (!tableId) return;
     if (!table) return;
+    if (!user) return;
     if (table.state !== "LOBBY") return;
     if (index <= 0) return;
 
     const current = players[index];
     const above = players[index - 1];
 
-    await swapSeats(
-      tableId,
-      current.id,
-      above.id,
-      current.seatIndex,
-      above.seatIndex
-    );
+    try {
+      await swapPlayerSeats(tableId, user, current.id, above.id);
+    } catch (err) {
+      setActionError(err instanceof Error ? err.message : null);
+    }
   }
 
   async function handleMoveDown(index: number) {
     if (!isHost) return;
     if (!tableId) return;
     if (!table) return;
+    if (!user) return;
     if (table.state !== "LOBBY") return;
     if (index >= players.length - 1) return;
 
     const current = players[index];
     const below = players[index + 1];
 
-    await swapSeats(
-      tableId,
-      current.id,
-      below.id,
-      current.seatIndex,
-      below.seatIndex
-    );
+    try {
+      await swapPlayerSeats(tableId, user, current.id, below.id);
+    } catch (err) {
+      setActionError(err instanceof Error ? err.message : null);
+    }
   }
 
   async function handleLeaveTable() {


### PR DESCRIPTION
## Summary

Seat order is a load-bearing invariant in this codebase: hand logic indexes players by **seat position rather than uid**, and every transactional API in `firestoreApi.ts` reads its player refs via `getDocs(orderBy("seatIndex"))` *outside* the transaction, on the assumption that order stays stable for the duration. Nothing enforced that assumption.

Closes the last unguarded mutating API, following #10.

## What was wrong

Two functions wrote `seatIndex`, and only one was safe:

| | host check | state guard | seat values |
|---|---|---|---|
| `swapPlayerSeats()` | yes | **no** | read from Firestore |
| `swapSeats()` | **no** | **no** | **taken from the caller** |

`swapSeats()` was the worse of the two in every dimension — and it was the one wired to the lobby reorder buttons. It wrote whatever seat numbers the client handed it, with nothing checking who was asking.

## The fix

**`swapSeats()` is deleted, not repaired.** It duplicated `swapPlayerSeats()` with strictly weaker safety, so `handleMoveUp`/`handleMoveDown` now call `swapPlayerSeats()` and inherit the host check for free. One implementation instead of two.

**`swapPlayerSeats()` gains the missing state guard and moves into a transaction.**

The guard is deliberately **"no live hand"** rather than **"LOBBY only"** — worth a look, since the obvious guard would have been wrong. The in-game reorder buttons at `TablePage.tsx:3556-3557` are gated on `disableEndGame`, not on lobby state, so **reordering between hands is a supported feature**. A `state !== "LOBBY"` guard would have silently broken it. The server-side check now mirrors `disableEndGame`: a hand at `SHOWDOWN` with a winner assigned counts as over.

**The transaction is what makes the guard real**, not incidental cleanup. As a read-then-`writeBatch`, a hand starting between the guard's read and the batch commit would let the swap land mid-hand regardless — which is the exact corruption being prevented. Reads now precede writes under the documented `LETTURA`/`SCRITTURA` discipline.

## Test plan

- `npx tsc -b` — clean, exit 0.
- `npx eslint .` — **134 errors, the documented baseline**. Worth noting: an intermediate version of this change added 3 `no-explicit-any` hits; I caught and removed them rather than shipping a widened baseline.
- Locale counts **387 / 386** — two keys added to each (`error.seatChangeDuringHand`, `error.playerNotFound`), the known one-key gap unchanged.

Manual checks against a throwaway table:

1. **Lobby reorder** — ▲▼ still work for the host.
2. **Non-host reorder** — rejected with "Only the host can perform this action."
3. **Mid-hand reorder** — call `swapPlayerSeats` directly during a live hand; rejected with the new message. This is the actual bug: previously it would land and shift dealer/SB/BB under the running hand.
4. **Between-hands reorder** — at showdown with a winner assigned, reordering still works. This is the regression to watch for; a LOBBY-only guard would break it.

## Notes

`CLAUDE.md` is updated **in this same commit** — it named `swapSeats` as the last unguarded API in two places, and both would have gone stale the moment this merged. Folding it in avoids the follow-up resync that #11 needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
