### PR TITLE
fix: make the split-pot remainder deterministic

### DIFF
--- a/frontend/src/lib/firestoreApi.ts
+++ b/frontend/src/lib/firestoreApi.ts
@@ -80,19 +80,46 @@ export interface Pot {
 }
 
 /**
- * Divide `amount` tra `numWinners` vincitori arrotondando al multiplo di 5 inferiore.
- * Il resto (sempre multiplo di 5) viene assegnato a un vincitore casuale.
- * Restituisce un array di importi della stessa lunghezza di `numWinners`.
+ * Hash stabile a 32 bit (FNV-1a). Serve solo a scegliere in modo riproducibile
+ * il destinatario del resto: nessun requisito crittografico.
  */
-function splitPot(amount: number, numWinners: number): number[] {
+function hashString(input: string): number {
+  let h = 0x811c9dc5;
+  for (let i = 0; i < input.length; i++) {
+    h ^= input.charCodeAt(i);
+    h = Math.imul(h, 0x01000193);
+  }
+  return h >>> 0;
+}
+
+/**
+ * Divide `amount` tra `winners` arrotondando al multiplo di 5 inferiore.
+ * Il resto (sempre multiplo di 5) viene assegnato a uno solo dei vincitori.
+ * Restituisce un array di importi della stessa lunghezza di `winners`.
+ *
+ * ATTENZIONE: lo stesso pot viene splittato più volte durante una singola
+ * assegnazione — una volta per accreditare gli stack, e di nuovo da
+ * computeChipsWonMap() per getStatsCandidateIds()/applyStatsUpdates(). Con un
+ * Math.random() interno le due chiamate sceglievano destinatari diversi: lo
+ * stack di un giocatore cresceva del resto mentre le stats lo attribuivano a un
+ * altro, e un vincitore con quota 0 nel secondo tiro spariva da candidateIds
+ * restando senza alcun aggiornamento. Il destinatario è quindi derivato in modo
+ * deterministico da (seed del pot, vincitori, importo): tutti i chiamanti
+ * ottengono la stessa ripartizione senza doversela passare l'un l'altro.
+ * `winners` viene ordinato prima di calcolare l'hash, così l'esito non dipende
+ * dall'ordine in cui i vari chiamanti costruiscono la lista.
+ */
+function splitPot(amount: number, winners: string[], seed: string): number[] {
+  const numWinners = winners.length;
   if (numWinners <= 0) return [];
   if (numWinners === 1) return [amount];
   const base = Math.floor(amount / numWinners / 5) * 5;
   const remainder = amount - base * numWinners;
   const shares = Array(numWinners).fill(base);
   if (remainder > 0) {
-    const luckyIdx = Math.floor(Math.random() * numWinners);
-    shares[luckyIdx] += remainder;
+    const sorted = [...winners].sort();
+    const luckyId = sorted[hashString(`${seed}|${amount}|${sorted.join(",")}`) % numWinners];
+    shares[winners.indexOf(luckyId)] += remainder;
   }
   return shares;
 }
@@ -104,7 +131,7 @@ function computeChipsWonMap(pots: Pot[]): Record<string, number> {
   const chipsWonMap: Record<string, number> = {};
   pots.forEach(pot => {
     if (pot.settled && pot.winners && pot.winners.length > 0) {
-      const shares = splitPot(pot.amount, pot.winners.length);
+      const shares = splitPot(pot.amount, pot.winners, pot.id);
       pot.winners.forEach((wId, idx) => {
         chipsWonMap[wId] = (chipsWonMap[wId] || 0) + shares[idx];
       });
@@ -239,7 +266,7 @@ function autoEvaluateShowdown(
       // Still need to credit chips for these!
       if (pot.winners && pot.winners.length > 0) {
         pot.winners.forEach(w => globalWinners.add(w));
-        const shares = splitPot(pot.amount, pot.winners.length);
+        const shares = splitPot(pot.amount, pot.winners, pot.id);
         pot.winners.forEach((wId, i) => {
           playerChipsWon[wId] = (playerChipsWon[wId] || 0) + shares[i];
           const w = players.find(p => p.id === wId);
@@ -282,7 +309,7 @@ function autoEvaluateShowdown(
     potWinners.forEach(w => globalWinners.add(w));
 
     // Distribute chips
-    const shares = splitPot(pot.amount, potWinners.length);
+    const shares = splitPot(pot.amount, potWinners, pot.id);
     potWinners.forEach((wId, i) => {
       playerChipsWon[wId] = (playerChipsWon[wId] || 0) + shares[i];
       const w = players.find(p => p.id === wId);
@@ -2119,7 +2146,7 @@ export async function advanceStage(tableId: string, user: User) {
         // Solo 1 giocatore — vince automaticamente, carte non mostrate
         calcPots.forEach(pt => {
           if (pt.settled && pt.winners && pt.winners.length > 0) {
-            const shares = splitPot(pt.amount, pt.winners.length);
+            const shares = splitPot(pt.amount, pt.winners, pt.id);
             pt.winners.forEach((wid, i) => {
               const w = plyrsData.find(p => p.id === wid);
               if (w) {
@@ -2159,7 +2186,7 @@ export async function advanceStage(tableId: string, user: User) {
         if (allPotsSettled) {
           calcPots.forEach(pt => {
             if (pt.settled && pt.winners && pt.winners.length > 0) {
-              const shares = splitPot(pt.amount, pt.winners.length);
+              const shares = splitPot(pt.amount, pt.winners, pt.id);
               pt.winners.forEach((wid, i) => {
                 const w = plyrsData.find(p => p.id === wid);
                 if (w) {
@@ -2367,7 +2394,9 @@ export async function confirmWinners(
     if (currentPotIndex === -1) {
       // Fallback legacy: nessun pot strutturato disponibile, usa il pot totale grezzo
       const pot = hand.pot || 0;
-      const shares = splitPot(pot, winnerIds.length);
+      // Stesso seed del pot simulato costruito più sotto per le stats ("pot_legacy"),
+      // altrimenti le due ripartizioni divergerebbero.
+      const shares = splitPot(pot, winnerIds, "pot_legacy");
       winnerIds.forEach((wId, i) => {
         const w = players.find(p => p.id === wId);
         if (w) {
@@ -2403,7 +2432,7 @@ export async function confirmWinners(
       }
 
       const distributePot = (targetPot: Pot, wins: string[]) => {
-        const shares = splitPot(targetPot.amount, wins.length);
+        const shares = splitPot(targetPot.amount, wins, targetPot.id);
         wins.forEach((wId, i) => {
           const w = players.find(p => p.id === wId);
           if (w) {


### PR DESCRIPTION
## Summary

`splitPot()` rounds each winner's share down to a multiple of 5 and hands the odd remainder to a single winner. It picked that winner with an internal `Math.random()` — but **the same pot is split more than once per settlement**: once to credit stacks (`autoEvaluateShowdown` / `advanceStage` / `confirmWinners`), and again via `computeChipsWonMap()` for `getStatsCandidateIds()` and `applyStatsUpdates()`. Each call re-rolled, so the two passes disagreed.

Two consequences:

- **Stats diverge from chips actually paid.** A 3-way tie on a pot of 40 splits as base 10, remainder 10. The stack credit gave the extra 10 to one winner while the stats pass attributed it to another, so `totalChipsWon` / `netProfit` stopped matching reality.
- **A winner could vanish from stats entirely.** When `base` rounds to 0 (small pot, several winners), a winner drawing a 0 share in the *stats* roll falls out of `getStatsCandidateIds()`, leaving `applyStatsUpdates()` with no user snapshot for them — no stats written at all.

The fix derives the recipient deterministically from `(pot seed, amount, sorted winners)` via a small FNV-1a hash, so every caller computes the same split independently. That choice matters structurally: threading a precomputed result through instead would have meant passing it across the read-before-write transaction boundary, and this keeps the existing transaction shape untouched.

## Review notes

I verified this independently rather than relying on the commit message. Reimplemented `splitPot` exactly as written here and exercised it over 1–9 winners × pots 0–2000 (**3,609 cases**):

- **Chip conservation** — `sum(shares) === amount` in every case. Nothing created or destroyed.
- **Determinism** — repeated calls with identical inputs always agree. This is the actual bug, fixed.
- **Order-independence** — the `[...winners].sort()` before hashing means callers that build the winners list in different orders still pay the same person. Confirmed by comparing forward and reversed orderings.

I also traced the legacy path in `confirmWinners`: the stack credit uses `splitPot(pot, winnerIds, "pot_legacy")` and the simulated stats pot is built with `id: "pot_legacy"`, the same `amount`, and the same `winners`, so those two passes provably cannot diverge. The seed comment is accurate.

## One behavior change worth a decision before merge

Pot IDs come from `calculatePotsCore` as `pot-0`, `pot-1`, … — **regenerated per hand, not globally unique**. The seed therefore contains nothing that varies from one hand to the next.

The practical effect: for a *recurring identical* pot — same pot index, same amount, same set of tied winners — **the same player receives the odd chips every single time**. Measured over 500 simulated hands, each such combination produced exactly 1 distinct recipient:

```
seed=pot-0      amount=25  -> player1   (1 distinct over 500 hands)
seed=pot-0      amount=40  -> player1   (1 distinct over 500 hands)
seed=pot-1      amount=25  -> player2   (1 distinct over 500 hands)
seed=pot_legacy amount=40  -> player0   (1 distinct over 500 hands)
```

Across *varying* amounts the distribution is fine (roughly 237 / 234 / 196 over three winners), which is what the commit message measured — that check passes but doesn't cover the repeat case.

This is a small, bounded edge (at most the remainder, under 5 × winners chips per occurrence) and it only bites when the exact same tie recurs, which fixed blinds make plausible. It is strictly less serious than the stat corruption being fixed here, so this is **not a blocker** — but it does replace "uniformly random" with "systematically the same player", and that's a fairness property in a poker app rather than an implementation detail.

**Suggested follow-up:** make the pot ID hand-unique at creation in `calculatePotsCore` (`${handId}-pot-${idx}`). The seed then varies per hand while staying identical across both passes within one settlement, which preserves the fix. Because `computeChipsWonMap` and every other caller already pass `pot.id`, **no call site changes** — and in-flight hands keep whatever IDs are stored in their doc, so nothing needs migrating.

## Test plan

- `npx tsc -b` — clean.
- `npx eslint .` — unchanged at the 134-error baseline.
- Independent simulation as described above: conservation, determinism, and order-independence all pass over 3,609 cases.

Worth confirming against a throwaway table: a 3-way tie on a pot with a non-zero remainder should leave each winner's `totalChipsWon` exactly matching the chips added to their stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
