### PR TITLE
fix: stop prompting registered users to pick a username after Google login

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -197,6 +197,15 @@ in-progress table session survives). Several non-obvious workarounds in there ar
 `linkedProviderIds` as separate state (Firebase mutates the `User` object in place, so identity-based
 re-render detection fails). Read the comments before refactoring that file.
 
+`isRegisteredUser: false` is **ambiguous on its own** — it means both "this user has no profile" and
+"the profile hasn't been read yet". `profileChecked` disambiguates, and anything that reacts to a
+*missing* profile must gate on it (`Layout`'s username modal, `ProfilePage`'s redirect). The gap is
+only observable on an **in-session** sign-in: `loading` goes true→false exactly once, on the first
+auth resolution, so on a page reload `App` holds a spinner until the profile read finishes, while a
+Google popup later in the session renders straight through the window where `onAuthStateChanged` has
+set `user` but not yet resolved the Firestore read. A read *failure* deliberately leaves
+`profileChecked` false, so an unanswered question never renders as "no profile".
+
 ### UI conventions
 
 - **No Tailwind** (the README is wrong). Styling is `frontend/src/styles/index.css` (~1.9k lines) with

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -13,7 +13,7 @@ export default function Layout({ children }: Props) {
   const { i18n, t } = useTranslation();
   const navigate = useNavigate();
   const location = useLocation();
-  const { user, isRegisteredUser, claimUsername, logout, isRegistering } = useAuth();
+  const { user, isRegisteredUser, profileChecked, claimUsername, logout, isRegistering } = useAuth();
 
   // .app-layout is a fixed-height (100dvh) flex column — the page itself never
   // scrolls. The actual scrollable element is this <main>, so a route change
@@ -54,7 +54,11 @@ export default function Layout({ children }: Props) {
   }
 
   const showHomeBtn = location.pathname !== "/home" && location.pathname !== "/";
-  const showUsernameModal = user && !user.isAnonymous && !isRegisteredUser && !isRegistering;
+  // profileChecked gates the whole thing: !isRegisteredUser also means "profile not read
+  // yet", and on an in-session sign-in that gap is a visible render — which is what made
+  // this modal flash up for users who already have a perfectly valid username.
+  const showUsernameModal =
+    user && !user.isAnonymous && profileChecked && !isRegisteredUser && !isRegistering;
 
   return (
     <div className="app-layout" id="app-layout-root">

--- a/frontend/src/hooks/useAuth.tsx
+++ b/frontend/src/hooks/useAuth.tsx
@@ -21,6 +21,11 @@ interface AuthContextValue {
   user: User | null;
   loading: boolean;
   isRegisteredUser: boolean;
+  // False until the signed-in user's Firestore profile has actually been read.
+  // `isRegisteredUser: false` on its own is ambiguous — it means both "no profile"
+  // and "haven't looked yet" — so anything that reacts to a *missing* profile must
+  // check this first. See the comment on the state declaration.
+  profileChecked: boolean;
   username: string | null;
   photoURL: string | null;
   login: (displayName: string) => Promise<void>;
@@ -116,6 +121,14 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   const [username, setUsername] = useState<string | null>(null);
   const [photoURL, setPhotoURL] = useState<string | null>(null);
   const [isRegisteredUser, setIsRegisteredUser] = useState(false);
+  // `loading` only ever goes true->false once, on the first auth resolution. A sign-in
+  // that happens *later in the same session* (Google popup from the login page) therefore
+  // renders with loading already false, unlike a page reload where <App> holds a spinner
+  // until the profile read has finished. Without a separate "have we looked yet?" flag,
+  // that difference is visible: onAuthStateChanged sets `user` synchronously but only
+  // learns whether a profile exists one await later, so for that gap an already-registered
+  // user looks exactly like a brand-new one.
+  const [profileChecked, setProfileChecked] = useState(false);
   const [loading, setLoading] = useState(true);
   const [isRegistering, setIsRegistering] = useState(false);
   // onAuthStateChanged below subscribes exactly once (empty dep array — resubscribing
@@ -134,6 +147,11 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       if (firebaseUser) {
         setUser(firebaseUser);
         if (!firebaseUser.isAnonymous) {
+          // Batched with setUser above, so the first render that sees this user already
+          // knows the profile is unverified. Re-armed on every sign-in because the flag
+          // is per-user, not per-session: a previous user's "checked" verdict says
+          // nothing about this one.
+          setProfileChecked(false);
           // Fetch username & photoURL from Firestore
           try {
             const userDoc = await getDoc(doc(db, "users", firebaseUser.uid));
@@ -162,23 +180,30 @@ export function AuthProvider({ children }: { children: ReactNode }) {
                 setIsRegisteredUser(false);
               }
             }
+            // Reached only when the read actually resolved, so isRegisteredUser now
+            // reflects the stored profile either way.
+            setProfileChecked(true);
           } catch (e) {
             // A transient read failure (network blip, brief offline window) is not
             // reliable evidence the user isn't registered — leave existing state
             // alone rather than bouncing an already-registered user back to the
-            // "choose a username" prompt.
+            // "choose a username" prompt. profileChecked deliberately stays false
+            // for the same reason: an unanswered question must not read as "no".
             console.error("Errore nel recupero dello username:", e);
           }
         } else {
           setIsRegisteredUser(false);
           setUsername(firebaseUser.displayName);
           setPhotoURL(null);
+          // Guests have no profile to check; nothing is pending.
+          setProfileChecked(true);
         }
       } else {
         setUser(null);
         setIsRegisteredUser(false);
         setUsername(null);
         setPhotoURL(null);
+        setProfileChecked(false);
       }
       setLoading(false);
     });
@@ -258,6 +283,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       
       setUsername(finalUsername);
       setIsRegisteredUser(true);
+      setProfileChecked(true);
       setPhotoURL(null);
       setUser(u);
     } catch (err) {
@@ -303,6 +329,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     const cred = await signInWithEmailAndPassword(auth, loginEmail, password);
     setUser(cred.user);
     setIsRegisteredUser(true);
+    setProfileChecked(true);
   }
 
   async function signInWithGoogle() {
@@ -329,6 +356,10 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       setIsRegisteredUser(!!dbUsername);
     }
 
+    // Both branches above read the profile doc, so the verdict is settled either way.
+    // This also re-closes the window that onAuthStateChanged opened when the popup
+    // resolved: it fires the moment sign-in completes and races this function.
+    setProfileChecked(true);
     setUser(u);
   }
 
@@ -383,6 +414,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     }
     
     setIsRegisteredUser(true);
+    setProfileChecked(true);
   }
 
   // Firebase's User object is mutable — linkWithCredential/linkWithPopup update
@@ -442,6 +474,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     setUsername(null);
     setPhotoURL(null);
     setIsRegisteredUser(false);
+    setProfileChecked(false);
   }
 
   async function claimUsername(desiredUsername: string) {
@@ -452,12 +485,14 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     setUsername(finalUsername);
     setPhotoURL(pUrl || null);
     setIsRegisteredUser(true);
+    setProfileChecked(true);
   }
 
   const value: AuthContextValue = {
     user,
     loading,
     isRegisteredUser,
+    profileChecked,
     username,
     photoURL,
     login,

--- a/frontend/src/routes/ProfilePage.tsx
+++ b/frontend/src/routes/ProfilePage.tsx
@@ -24,7 +24,7 @@ import { deleteAccount } from "../lib/firestoreApi";
 
 export default function ProfilePage() {
   const {
-    user, username, isRegisteredUser, photoURL, updatePhotoURL,
+    user, username, isRegisteredUser, profileChecked, photoURL, updatePhotoURL,
     linkedProviderIds, linkEmailPasswordToAccount, linkGoogleToAccount
   } = useAuth();
   const navigate = useNavigate();
@@ -96,11 +96,15 @@ export default function ProfilePage() {
   }, [searchParams]);
 
   useEffect(() => {
-    if (!isRegisteredUser) {
+    // Wait for the profile read before bouncing anyone: !isRegisteredUser is also true
+    // while the check is still in flight, which would eject a registered user who lands
+    // here right after signing in. The logged-out case is already handled by the route
+    // guard in App.tsx, so this only ever decides registered-vs-guest.
+    if (profileChecked && !isRegisteredUser) {
       navigate("/home");
       return;
     }
-  }, [isRegisteredUser, navigate]);
+  }, [profileChecked, isRegisteredUser, navigate]);
 
   // Fetch full profile and stats
   useEffect(() => {


### PR DESCRIPTION
## The bug

Signing in with Google surfaced the "choose your username" modal to users who already have a valid one. Reloading the page cleared it, and it didn't come back — and that asymmetry is what identifies the cause.

## Why it happens

`Layout` gated the modal on:

```ts
user && !user.isAnonymous && !isRegisteredUser && !isRegistering
```

`isRegisteredUser: false` carries **two different meanings**: *"this user has no profile"* and *"we haven't looked yet"*. `onAuthStateChanged` sets `user` synchronously, then `await`s a Firestore read before it can set `isRegisteredUser`. For the length of that round trip, an established account is indistinguishable from a brand-new one — so the modal renders.

**Why reloading appeared to fix it:** `loading` goes `true → false` exactly once, at the end of the first auth resolution, and `<App>` holds a spinner while it's true.

- **Page reload** — `loading` starts true, the spinner covers the entire read, and the first render of `Layout` already has the correct verdict. Modal never appears.
- **In-session Google sign-in** — `loading` is *already* false (it flipped when the logged-out state resolved). Nothing covers the gap, so the intermediate render goes to screen.

Same code, different visibility. The reload wasn't fixing state; it was hiding the window.

## The fix

Adds `profileChecked` to the auth context — false until the profile read actually resolves, and re-armed on every sign-in, since the flag is per-user rather than per-session (a previous user's verdict says nothing about this one).

A read **failure** deliberately leaves it false. That mirrors the intent already documented in the existing `catch`, which refuses to downgrade an established user on a transient read error: an unanswered question must not render as "no profile". This also covers the case where the modal *persists* rather than flashing, which is what a failed read would produce.

The two writers race by design — `onAuthStateChanged` fires the moment the popup resolves, alongside `signInWithGoogle`'s own read — so both set the flag. Both interleavings are safe: the worst case is the modal staying hidden a beat longer, never a false prompt.

## Second instance of the same ambiguity

`ProfilePage` had a `useEffect` redirecting to `/home` on `!isRegisteredUser`, which could **eject a registered user** who landed there right after signing in. Now gated on `profileChecked` too. The logged-out case is already handled by the route guard in `App.tsx` (`user ? <ProfilePage /> : <Navigate to="/" />`), so that effect only ever decides registered-vs-guest — gating it can't strand anyone.

The two add-friend handlers (`HomePage`, `PlayerProfilePage`) also branch on `!isRegisteredUser` but are **deliberately left alone**: they run on click, long after the read settles, and degrade to a harmless error message rather than a redirect.

## Test plan

- `npx tsc -b` — clean, exit 0.
- `npx eslint .` — 134 errors, the documented baseline. No new debt.

**Not reproduced locally** — Google OAuth needs a real popup, and this repo has no test runner or auth emulator. The mechanism is established by reading the state transitions rather than by observing the fix, so the check that matters is manual:

1. Sign in with Google on an account that already has a username → **no modal** (the reported bug).
2. Sign in with Google on a genuinely new account → modal still appears, and claiming a username still works.
3. Reload while signed in → still no modal (unchanged behaviour).
4. Sign in, then go straight to `/profile` → not bounced to `/home`.
5. Guest → registered upgrade via `linkGuestToRegistered` → unchanged.

## Notes

`CLAUDE.md` updated in the same commit. Its Auth section already catalogues the non-obvious workarounds in `useAuth.tsx`, and this is squarely one of them — the `loading`-flips-once detail is the kind of thing that costs an hour to rediscover.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
