### PR TITLE
fix: qualify pot ids with the hand id so split remainders vary per hand

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -158,10 +158,21 @@ ever writes — treat it as vestigial, not a fourth state.
 
 Pots: `calculatePotsCore()` derives cascading side pots from `handContributions`; a pot with ≤1
 eligible player auto-settles. `splitPot()` rounds shares down to a multiple of 5 and hands the
-remainder to a random winner, so chip totals stay integral. **It picks that winner with an internal
-`Math.random()` and is called more than once per settlement** (once to credit stacks, again from
-`getStatsCandidateIds`/`applyStatsUpdates`), so the rolls disagree and recorded stats can diverge
-from the chips actually paid. Compute the split once and thread the result through.
+remainder to one winner, so chip totals stay integral.
+
+**It is called more than once per settlement** — once to credit stacks, again from
+`computeChipsWonMap()` for `getStatsCandidateIds`/`applyStatsUpdates` — so the passes must agree or
+recorded stats drift from the chips actually paid. They agree by being *deterministic*, not by
+threading a result through: the recipient is an FNV-1a hash of `(pot.id, amount, sorted winners)`.
+Recomputing is deliberate — passing a precomputed split between those call sites would mean carrying
+it across the read-before-write transaction boundary.
+
+Two properties that look incidental and are not. The winners list is **sorted before hashing**, so
+the outcome doesn't depend on the order each caller happens to build it in. And `pot.id` is
+**qualified with the hand id** (`${handId}-pot-N`, from `calculatePotsCore`) — with per-hand ids like
+`pot-0` the seed never varied between hands, so an identical recurring split (same pot, same amount,
+same winners) handed the remainder to the same player every time. Any new seed component must keep
+both: stable within a settlement, varying across hands.
 
 ### Two card modes, one engine
 

--- a/frontend/src/lib/firestoreApi.ts
+++ b/frontend/src/lib/firestoreApi.ts
@@ -1097,7 +1097,8 @@ export async function forceFoldPlayer(
           id: p.id,
           isFolded: p.id === targetPlayerId ? true : !!p.data.isFolded
         })),
-        handContributions
+        handContributions,
+        handId
       );
 
       // Auto-settle all pots for the only remaining player
@@ -1739,7 +1740,8 @@ export async function playerAction(
       nextTurnIndex = -1;
       potsCalculatedFastForward = calculatePotsCore(
         players.map(p => ({ id: p.userId, isFolded: p.isFolded })),
-        handContributions
+        handContributions,
+        currentHandId
       );
     } else if (actingPlayers.length <= 1) {
       // Tutti gli altri sono in all-in o foldati: solo 1 o 0 possono ancora scommettere
@@ -1755,7 +1757,8 @@ export async function playerAction(
         nextTurnIndex = -1;
         potsCalculatedFastForward = calculatePotsCore(
           players.map(p => ({ id: p.userId, isFolded: p.isFolded })),
-          handContributions
+          handContributions,
+          currentHandId
         );
       } else {
         // Non va ancora a showdown: verifica se tutti hanno matched la puntata (O SONO IN ALL-IN!)
@@ -1830,7 +1833,8 @@ export async function playerAction(
               nextTurnIndex = -1;
               potsCalculatedFastForward = calculatePotsCore(
                 players.map(p => ({ id: p.userId, isFolded: p.isFolded })),
-                handContributions
+                handContributions,
+                currentHandId
               );
             } else {
               nextTurnIndex = -1;
@@ -1865,7 +1869,8 @@ export async function playerAction(
       // Durante il gioco: ricalcola live i pot per mostrare i side-pot nell'UI
       handUpdate.pots = calculatePotsCore(
         players.map(p => ({ id: p.userId, isFolded: p.isFolded })),
-        handContributions
+        handContributions,
+        currentHandId
       );
     }
 
@@ -2165,7 +2170,7 @@ export async function advanceStage(tableId: string, user: User) {
       const activePlayers = plyrsData.filter(p => !p.isFolded);
 
       // Calcoliamo i side pots da mettere nel DB
-      const calcPots = calculatePotsCore(plyrsData, hand.handContributions || {});
+      const calcPots = calculatePotsCore(plyrsData, hand.handContributions || {}, currentHandId);
       updateData.pots = calcPots;
 
       if (activePlayers.length <= 1) {
@@ -2269,7 +2274,16 @@ export async function advanceStage(tableId: string, user: User) {
   });
 }
 
-export function calculatePotsCore(players: {id: string, isFolded: boolean}[], contributions: Record<string, number>): Pot[] {
+/**
+ * `handId` entra solo nell'id dei pot, ma non è cosmetico: l'id è il seed con cui
+ * splitPot() sceglie il destinatario del resto. Con id ripetuti a ogni mano
+ * (`pot-0`, `pot-1`, ...) lo stesso identico split — stesso pot, stesso importo,
+ * stessi vincitori — assegnava il resto sempre allo stesso giocatore, mano dopo
+ * mano. Qualificando l'id con la mano il seed cambia a ogni mano, restando però
+ * identico tra le due chiamate di splitPot() della stessa assegnazione (accredito
+ * stack e pass delle stats), che è la proprietà da cui dipende la correttezza.
+ */
+export function calculatePotsCore(players: {id: string, isFolded: boolean}[], contributions: Record<string, number>, handId: string): Pot[] {
   // Discard amounts of 0
   const amounts = Object.values(contributions).filter(v => v > 0).sort((a,b) => a - b);
   const sortedAmounts = [...new Set(amounts)];
@@ -2295,7 +2309,7 @@ export function calculatePotsCore(players: {id: string, isFolded: boolean}[], co
     });
     
     pots.push({
-      id: `pot-${potIdx++}`,
+      id: `${handId}-pot-${potIdx++}`,
       amount: potSize,
       eligible,
       settled: eligible.length <= 1,
@@ -2404,7 +2418,8 @@ export async function confirmWinners(
     if (pots.length === 0 && hand.handContributions && Object.keys(hand.handContributions).length > 0) {
       pots = calculatePotsCore(
         players.map(p => ({ id: p.id, isFolded: p.data.isFolded })),
-        hand.handContributions
+        hand.handContributions,
+        currentHandId
       );
     }
 


### PR DESCRIPTION
## Summary

Follow-up to #13, closing the one issue that review turned up.

#13 made the split-pot remainder deterministic by seeding an FNV-1a hash with the pot id, fixing stats that diverged from the chips actually paid. But `calculatePotsCore` numbered pots `pot-0`, `pot-1`, … **restarting every hand**, so the seed contained nothing that varied between hands.

The consequence: for an identical recurring split — same pot index, same amount, same set of tied winners — **the same player collected the odd chips every single time**.

## Measured

3,000 hands of a 3-way tie on a pot of 40 (base 10, remainder 10):

| | alice | bob | carol | distinct recipients |
|---|---|---|---|---|
| **before** (`pot-0`) | — | **100.0%** | — | 1 |
| **after** (`${handId}-pot-0`) | 34.0% | 32.7% | 33.2% | 3 |

Small stakes — under 5 × winners chips per occurrence — but systematic rather than random, and fixed blinds make exact repeats plausible. The `Math.random()` this replaced was at least unbiased; determinism shouldn't have cost that.

## The fix

`calculatePotsCore` takes `handId` and emits `${handId}-pot-N`.

Every caller already had a hand id in scope (`handId` in `forceFoldPlayer`, `currentHandId` in `playerAction` / `advanceStage` / `confirmWinners`), and every consumer already passes `pot.id` as the seed — so nothing else moves. Seven call sites, one new argument each.

**No migration.** Pots are persisted on the hand doc, and `confirmWinners` only recalculates when `hand.pots` is empty — otherwise it matches `potId` against the stored array. Hands created before this keep their stored `pot-N` ids and settle exactly as before.

## Test plan

The property #13 depends on must survive: within a single settlement, the stack-credit pass and the `computeChipsWonMap` stats pass must produce the same split. Both read the same `pot.id`, so both still agree — verified over 3,000 randomized settlements, with chip conservation checked alongside: **3000/3000 OK**.

- `npx tsc -b` — clean, exit 0.
- `npx eslint .` — 134 errors, the documented baseline.

Worth confirming against a throwaway table: a 3-way tie with a non-zero remainder should still leave each winner's `totalChipsWon` exactly matching the chips added to their stack — and across several such hands, the extra chips should not always land on the same player.

## Note

Also corrects the `CLAUDE.md` pots paragraph. It still described the **pre-#13** `Math.random()` behaviour and advised "compute the split once and thread the result through" — now the opposite of how this works, and specifically unworkable, since threading a result between those call sites would mean carrying it across the read-before-write transaction boundary. #13 changed the code without updating that paragraph.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
