### PR TITLE
fix: add missing joinTable.gameInProgressWarning to it.json

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -216,8 +216,8 @@ set `user` but not yet resolved the Firestore read. A read *failure* deliberatel
   `kickConfirmModalUI`, …) assembled at the bottom of the component — native `confirm()`/`alert()`
   were deliberately removed, so follow that pattern for new prompts.
 - Almost all user-facing text goes through `react-i18next` (`locales/en.json`, `locales/it.json`; add
-  keys to **both** — the current baseline is 387 vs 386 keys, `it.json` is missing
-  `joinTable.gameInProgressWarning`). The documented exception is `components/ReloadPrompt.tsx`,
+  keys to **both** — the two files are now at parity, 387 keys each, so any difference is a
+  regression rather than a pre-existing gap). The documented exception is `components/ReloadPrompt.tsx`,
   which branches on `i18n.resolvedLanguage === 'it'` and inlines both translations, so its strings
   are invisible to anyone grepping the locale files.
 - User-visible errors thrown from `firestoreApi.ts` should be i18n keys — `throw new

--- a/frontend/src/locales/it.json
+++ b/frontend/src/locales/it.json
@@ -90,7 +90,8 @@
     "submitBtn": "Entra nel Tavolo",
     "hint": "Chiedi l'ID e la password al creatore del tavolo (se prevista), o scansiona direttamente il loro codice QR d'invito.",
     "scanQrBtn": "Scansiona QR Invito",
-    "cancelScanBtn": "Annulla Scansione"
+    "cancelScanBtn": "Annulla Scansione",
+    "gameInProgressWarning": "🟡 La partita è già in corso. Entrerai come spettatore e potrai partecipare dalla prossima mano."
   },
   "table": {
     "errorNotLoggedIn": "Devi effettuare il login per vedere questo tavolo.",


### PR DESCRIPTION
## Summary

Italian users joining a table mid-game saw the raw key `joinTable.gameInProgressWarning` instead of the warning that they'll be seated as a spectator until the next hand. The key has existed in `en.json` only.

Brings the two locale files to **parity at 387 keys each**. `CLAUDE.md` has carried this as a known gap since #9; its i18n note now describes any difference as a regression rather than a documented pre-existing gap.

Translation matches the English string's content and tone, including the 🟡 prefix:

> 🟡 La partita è già in corso. Entrerai come spettatore e potrai partecipare dalla prossima mano.

## Test plan

- `npx tsc -b` — clean.
- Key counts verified equal: en 387 / it 387.
- To confirm in-app: switch to Italian and join a table that is already `IN_GAME`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)