### PR TITLE
fix: make endGame transactional so concurrent closes can't double stats

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -132,15 +132,19 @@ phases. Adding a read after a write silently breaks the transaction at runtime.
 Operations that can't fit one transaction (e.g. `startNextHand` discovering the tournament is over)
 set a flag and call the follow-up (`endGame()`) after the transaction commits.
 
+`endGame()` follows the standard shape and is worth reading as the worked example of *why* it
+exists. Its `state === "SUMMARY"` guard alone was not enough: as a read-then-`writeBatch`, two
+clients closing the same table both read `IN_GAME` before either committed, both passed the guard,
+and both incremented `stats.sessionsPlayed`/`stats.timePlayedSeconds`. The guard only became real
+once the table read moved inside `runTransaction` — a concurrent commit now forces a retry, and the
+retry sees `SUMMARY` and aborts. A guard is only as strong as the read it sits on.
+`scripts/end-stale-tables.mjs` was made transactional in the same change and skips (rather than
+throwing) when it loses that race, so one table closing under it doesn't abort the whole sweep.
+It can read a query inside its transaction because `firebase-admin` allows that and the Web SDK
+does not — the one deliberate divergence between the two implementations.
+
 Known exceptions to the shape above — don't read them as the pattern:
 
-- `endGame()` is **not transactional at all**: it does `getDoc`/`getDocs` and then commits a
-  `writeBatch`. Its `state === "SUMMARY"` guard rejects a *sequential* re-end (the case that used to
-  silently double every player's `stats.sessionsPlayed`), but it does **not** close the concurrent
-  race: two clients that both read before either commits both see `IN_GAME`, both pass the guard,
-  and both increment `stats.sessionsPlayed`/`stats.timePlayedSeconds`. Making that safe needs the
-  read and the write in one transaction, not a stronger guard. `scripts/end-stale-tables.mjs`
-  mirrors the same read-then-batch shape, so the race exists server-side too.
 - `endGame()` and `confirmWinners()` call `getDocs(playersRef)` with **no `orderBy`**, so their
   `playerRefs` are *not* in seat order. Don't index them positionally.
 

--- a/frontend/src/lib/firestoreApi.ts
+++ b/frontend/src/lib/firestoreApi.ts
@@ -1170,89 +1170,114 @@ export async function forceFoldPlayer(
   });
 }
 
+/**
+ * Chiude la partita e scrive il recap sul documento del tavolo.
+ *
+ * Transazionale, e non solo per abitudine: lo `state === "SUMMARY"` da solo non
+ * bastava. Con il vecchio read-then-writeBatch due client che chiudevano lo stesso
+ * tavolo leggevano entrambi IN_GAME prima che uno dei due committasse, passavano
+ * entrambi il guard e incrementavano entrambi stats.sessionsPlayed e
+ * stats.timePlayedSeconds. Dentro runTransaction la lettura del tavolo è
+ * sorvegliata: se un altro client committa nel frattempo la transazione riparte,
+ * la seconda volta legge SUMMARY ed esce senza scrivere.
+ *
+ * `scripts/end-stale-tables.mjs` duplica questa logica lato server e ha la stessa
+ * corsa: è stato reso transazionale insieme a questo. Cambiando uno, cambiare l'altro.
+ */
 export async function endGame(tableId: string, user: User) {
   const tableRef = doc(db, "tables", tableId);
-  const tableSnap = await getDoc(tableRef);
-  if (!tableSnap.exists()) throw new Error("error.tableNotFound");
-  const tableData = tableSnap.data() as any;
 
-  if (tableData.hostId !== user.uid) {
-    throw new Error("error.onlyHost");
-  }
-
-  // Senza questo guard, ri-terminare un tavolo già in SUMMARY ri-incrementa
-  // stats.sessionsPlayed e stats.timePlayedSeconds di ogni giocatore.
-  if (tableData.state === "SUMMARY") {
-    throw new Error("error.gameAlreadyEnded");
-  }
-
+  // Fuori dalla transazione: le transazioni non possono eseguire query, quindi questa
+  // serve solo a sapere QUALI player doc esistono. I valori vengono riletti dentro.
   const playersSnap = await getDocs(collection(db, "tables", tableId, "players"));
-  const userSnaps: Record<string, any> = {};
+  const playerRefs = playersSnap.docs.map((d) => d.ref);
 
-  const playersData = await Promise.all(playersSnap.docs.map(async (d) => {
-    const p = d.data();
-    const finalStack = Number(p.stack) || 0;
+  await runTransaction(db, async (transaction) => {
+    // ===== LETTURA =====
+    const tableSnap = await transaction.get(tableRef);
+    if (!tableSnap.exists()) throw new Error("error.tableNotFound");
+    const tableData = tableSnap.data() as any;
+
+    if (tableData.hostId !== user.uid) {
+      throw new Error("error.onlyHost");
+    }
+
+    // Rivalutato a ogni retry: è questo, unito alla lettura sorvegliata del tavolo,
+    // a rendere la chiusura idempotente sotto concorrenza.
+    if (tableData.state === "SUMMARY") {
+      throw new Error("error.gameAlreadyEnded");
+    }
+
+    const playerSnaps = await Promise.all(playerRefs.map((r) => transaction.get(r)));
+    const livePlayers = playerSnaps.filter((s) => s.exists());
+
+    // Le stats si leggono qui, prima di qualsiasi scrittura. Dedup per userId: due
+    // player doc possono riferirsi allo stesso utente (collisione di seatIndex dopo
+    // leaveTable + joinTable), e rileggerlo due volte non aggiungerebbe nulla.
+    const userIds = Array.from(
+      new Set(livePlayers.map((s) => s.data()!.userId).filter(Boolean))
+    );
+    const userSnapList = await Promise.all(
+      userIds.map((id) => transaction.get(doc(db, "users", id)))
+    );
+    const userSnaps = new Map(userSnapList.map((s) => [s.id, s]));
+
+    // ===== CALCOLO =====
     const initialStack = Number(tableData.initialStack) || 0;
-    const totalBuyIn = Number(p.totalBuyIn) || initialStack;
+    const wasInGame = tableData.state === "IN_GAME";
 
-    // Check if player is registered in users collection (still needed for stats update)
-    const userDocRef = doc(db, "users", p.userId);
-    const userSnap = await getDoc(userDocRef);
+    const playersData = livePlayers.map((s) => {
+      const p = s.data()!;
+      const finalStack = Number(p.stack) || 0;
+      const totalBuyIn = Number(p.totalBuyIn) || initialStack;
 
-    if (userSnap.exists()) {
-      userSnaps[p.userId] = userSnap.data();
+      let elapsedSeconds = 0;
+      if (wasInGame && p.satAt) {
+        elapsedSeconds = Math.floor((Date.now() - p.satAt) / 1000);
+      }
+
+      return {
+        userId: p.userId,
+        startingStack: initialStack,
+        finalStack: finalStack,
+        netProfit: finalStack - totalBuyIn,
+        sessionTimeSeated: (p.accumulatedTime || 0) + elapsedSeconds
+      };
+    });
+
+    const playerIds = playersData.map((p) => p.userId);
+
+    // ===== SCRITTURA =====
+    // Il recap sta sul documento del tavolo — non esiste una collection di storico.
+    transaction.update(tableRef, {
+      state: "SUMMARY",
+      endedAt: serverTimestamp(),
+      playerIds,
+      players: playersData
+    });
+
+    // Aggiorna sessionsPlayed e timePlayedSeconds per ciascun utente registrato
+    for (const p of playersData) {
+      const userSnap = userSnaps.get(p.userId);
+      if (userSnap && userSnap.exists()) {
+        const currentStats = userSnap.data().stats || {};
+        transaction.update(doc(db, "users", p.userId), {
+          "stats.sessionsPlayed": (currentStats.sessionsPlayed || 0) + 1,
+          "stats.timePlayedSeconds":
+            (currentStats.timePlayedSeconds || 0) + (p.sessionTimeSeated || 0)
+        });
+      }
     }
 
-    // Calculate sitting time for this game session
-    let elapsedSeconds = 0;
-    if (tableData.state === "IN_GAME" && p.satAt) {
-      elapsedSeconds = Math.floor((Date.now() - p.satAt) / 1000);
-    }
-    const sessionTimeSeated = (p.accumulatedTime || 0) + elapsedSeconds;
-
-    return {
-      userId: p.userId,
-      startingStack: initialStack,
-      finalStack: finalStack,
-      netProfit: finalStack - totalBuyIn,
-      sessionTimeSeated
-    };
-  }));
-
-  const playerIds = playersData.map((p) => p.userId);
-
-  const batch = writeBatch(db);
-
-  // Write summary data directly on the table document — no separate table_history collection
-  batch.update(tableRef, {
-    state: "SUMMARY",
-    endedAt: serverTimestamp(),
-    playerIds,
-    players: playersData
-  });
-
-  // Aggiorna sessionsPlayed e timePlayedSeconds per ciascun utente registrato
-  for (const p of playersData) {
-    if (userSnaps[p.userId]) {
-      const userDocRef = doc(db, "users", p.userId);
-      const currentStats = userSnaps[p.userId].stats || {};
-      const prevSeconds = currentStats.timePlayedSeconds || 0;
-      batch.update(userDocRef, {
-        "stats.sessionsPlayed": (currentStats.sessionsPlayed || 0) + 1,
-        "stats.timePlayedSeconds": prevSeconds + (p.sessionTimeSeated || 0)
+    // Resetta i contatori temporanei sui player document del tavolo. Solo quelli
+    // ancora esistenti: transaction.update() su un doc cancellato fa fallire tutto.
+    for (const s of livePlayers) {
+      transaction.update(s.ref, {
+        satAt: null,
+        accumulatedTime: 0
       });
     }
-  }
-
-  // Resetta i contatori temporanei sui player document del tavolo
-  playersSnap.docs.forEach((docSnap) => {
-    batch.update(docSnap.ref, {
-      satAt: null,
-      accumulatedTime: 0
-    });
   });
-
-  await batch.commit();
 }
 
 /**

--- a/scripts/end-stale-tables.mjs
+++ b/scripts/end-stale-tables.mjs
@@ -10,6 +10,7 @@
 // Auth: expects GOOGLE_APPLICATION_CREDENTIALS to point at a service-account
 // JSON key with Firestore access (roles/datastore.user is sufficient).
 
+import { pathToFileURL } from "node:url";
 import { initializeApp, applicationDefault, cert } from "firebase-admin/app";
 import { getFirestore, FieldValue, Timestamp } from "firebase-admin/firestore";
 
@@ -33,32 +34,73 @@ function toMillis(value) {
   return null;
 }
 
-async function endStaleTable(db, tableSnap) {
+// Transactional for the same reason the client endGame() is: the outer query
+// selects IN_GAME tables, but the host can end one between that query and this
+// write. Read-then-batch let both paths read the pre-end state and both increment
+// stats.sessionsPlayed / stats.timePlayedSeconds. Re-reading the table inside the
+// transaction makes the read guarded — a concurrent commit forces a retry, and the
+// retry sees SUMMARY and skips.
+//
+// Returns the outcome so main() can log it without aborting the whole sweep: a
+// table someone else just closed is an expected race, not a failure.
+export async function endStaleTable(db, tableSnap) {
   const tableId = tableSnap.id;
-  const tableData = tableSnap.data();
+  const tableRef = db.collection("tables").doc(tableId);
+  let outcome;
+  let playerCount = 0;
 
-  const playersSnap = await db.collection("tables").doc(tableId).collection("players").get();
-  const userSnaps = {};
+  await db.runTransaction(async (t) => {
+    // Reset per attempt — the transaction body re-runs on contention, so nothing
+    // in here may accumulate or log; both are done once, by the caller, after it
+    // has actually committed.
+    outcome = "ended";
+    playerCount = 0;
 
-  const playersData = await Promise.all(
-    playersSnap.docs.map(async (d) => {
+    // ===== READS =====
+    const freshTable = await t.get(tableRef);
+    if (!freshTable.exists) {
+      outcome = "vanished";
+      return;
+    }
+    const tableData = freshTable.data();
+
+    // The state we selected on may no longer hold.
+    if (tableData.state !== "IN_GAME") {
+      outcome = "already-ended";
+      return;
+    }
+
+    // Unlike the Web SDK, firebase-admin can read a query inside a transaction, so
+    // the player set is read under the same guard rather than fetched beforehand.
+    const playersSnap = await t.get(tableRef.collection("players"));
+
+    const userIds = [
+      ...new Set(playersSnap.docs.map((d) => d.data().userId).filter(Boolean))
+    ];
+    const userSnaps = {};
+    if (userIds.length > 0) {
+      const snaps = await Promise.all(
+        userIds.map((id) => t.get(db.collection("users").doc(id)))
+      );
+      for (const s of snaps) {
+        if (s.exists) userSnaps[s.id] = s.data();
+      }
+    }
+
+    // ===== COMPUTE =====
+    const initialStack = Number(tableData.initialStack) || 0;
+
+    const playersData = playersSnap.docs.map((d) => {
       const p = d.data();
       const finalStack = Number(p.stack) || 0;
-      const initialStack = Number(tableData.initialStack) || 0;
       const totalBuyIn = Number(p.totalBuyIn) || initialStack;
 
-      const userSnap = await db.collection("users").doc(p.userId).get();
-      if (userSnap.exists) {
-        userSnaps[p.userId] = userSnap.data();
-      }
-
-      // Table is still IN_GAME at sweep time by construction, same as the
-      // `tableData.state === "IN_GAME"` check in the client endGame().
+      // Table is still IN_GAME here by the guard above, same as the client's
+      // `wasInGame` check in endGame().
       let elapsedSeconds = 0;
       if (p.satAt) {
         elapsedSeconds = Math.floor((Date.now() - p.satAt) / 1000);
       }
-      const sessionTimeSeated = (p.accumulatedTime || 0) + elapsedSeconds;
 
       return {
         ref: d.ref,
@@ -66,45 +108,52 @@ async function endStaleTable(db, tableSnap) {
         startingStack: initialStack,
         finalStack,
         netProfit: finalStack - totalBuyIn,
-        sessionTimeSeated
+        sessionTimeSeated: (p.accumulatedTime || 0) + elapsedSeconds
       };
-    })
-  );
+    });
 
-  const playerIds = playersData.map((p) => p.userId);
+    const playerIds = playersData.map((p) => p.userId);
+    playerCount = playerIds.length;
 
-  if (DRY_RUN) {
-    console.log(`[dry-run] Would end table ${tableId} (${playerIds.length} players)`);
-    return;
-  }
+    if (DRY_RUN) {
+      outcome = "dry-run";
+      return; // no writes — the transaction commits empty
+    }
 
-  const batch = db.batch();
+    // ===== WRITES =====
+    t.update(tableRef, {
+      state: "SUMMARY",
+      endedAt: FieldValue.serverTimestamp(),
+      endedByAutoSweep: true,
+      playerIds,
+      players: playersData.map(({ ref, ...rest }) => rest)
+    });
 
-  batch.update(db.collection("tables").doc(tableId), {
-    state: "SUMMARY",
-    endedAt: FieldValue.serverTimestamp(),
-    endedByAutoSweep: true,
-    playerIds,
-    players: playersData.map(({ ref, ...rest }) => rest)
+    for (const p of playersData) {
+      if (userSnaps[p.userId]) {
+        const currentStats = userSnaps[p.userId].stats || {};
+        const prevSeconds = currentStats.timePlayedSeconds || 0;
+        t.update(db.collection("users").doc(p.userId), {
+          "stats.sessionsPlayed": (currentStats.sessionsPlayed || 0) + 1,
+          "stats.timePlayedSeconds": prevSeconds + (p.sessionTimeSeated || 0)
+        });
+      }
+    }
+
+    for (const p of playersData) {
+      t.update(p.ref, { satAt: null, accumulatedTime: 0 });
+    }
   });
 
-  for (const p of playersData) {
-    if (userSnaps[p.userId]) {
-      const currentStats = userSnaps[p.userId].stats || {};
-      const prevSeconds = currentStats.timePlayedSeconds || 0;
-      batch.update(db.collection("users").doc(p.userId), {
-        "stats.sessionsPlayed": (currentStats.sessionsPlayed || 0) + 1,
-        "stats.timePlayedSeconds": prevSeconds + (p.sessionTimeSeated || 0)
-      });
-    }
+  if (outcome === "ended") {
+    console.log(`Ended stale table ${tableId} (${playerCount} players, idle since last hand)`);
+  } else if (outcome === "dry-run") {
+    console.log(`[dry-run] Would end table ${tableId} (${playerCount} players)`);
+  } else {
+    console.log(`Skipped table ${tableId}: ${outcome} before the sweep could close it`);
   }
 
-  for (const p of playersData) {
-    batch.update(p.ref, { satAt: null, accumulatedTime: 0 });
-  }
-
-  await batch.commit();
-  console.log(`Ended stale table ${tableId} (${playerIds.length} players, idle since last hand)`);
+  return outcome;
 }
 
 async function main() {
@@ -129,17 +178,25 @@ async function main() {
 
     const idleMs = now - referenceMs;
     if (idleMs >= STALE_THRESHOLD_MS) {
-      await endStaleTable(db, tableSnap);
-      endedCount++;
+      const outcome = await endStaleTable(db, tableSnap);
+      if (outcome === "ended") endedCount++;
     }
   }
 
   console.log(`Done. Ended ${endedCount} stale table(s).`);
 }
 
-main()
-  .then(() => process.exit(0))
-  .catch((err) => {
-    console.error("Sweep failed:", err);
-    process.exit(1);
-  });
+// Only sweep when invoked as a script. Importing this module (e.g. to exercise
+// endStaleTable against a fake db — there is no Firestore emulator configured, and
+// the service-account key exists only as a CI secret) must not hit the real project.
+const invokedDirectly =
+  process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href;
+
+if (invokedDirectly) {
+  main()
+    .then(() => process.exit(0))
+    .catch((err) => {
+      console.error("Sweep failed:", err);
+      process.exit(1);
+    });
+}


### PR DESCRIPTION
## The bug

The `state === "SUMMARY"` guard added in #10 rejected a *sequential* re-end, but it sat on an **unguarded read**. As a read-then-`writeBatch`, two clients closing the same table both read `IN_GAME` before either committed, both passed the guard, and both incremented `stats.sessionsPlayed` and `stats.timePlayedSeconds` for every player at the table.

A guard is only as strong as the read it sits on. This was the last known correctness bug affecting stored player stats.

## The fix

`endGame` now runs inside `runTransaction`, following the shape CLAUDE.md documents: `getDocs` outside purely to learn which player docs exist, then table, players and users all read inside before any write.

The **table read** is what does the work — a concurrent commit forces a retry, and the retry sees `SUMMARY` and throws `error.gameAlreadyEnded` instead of writing.

Three details that aren't obvious:

- **User docs are deduped by `userId` before reading.** Two player docs can point at the same user after the `leaveTable` + `joinTable` seat collision CLAUDE.md describes, and reading the same ref twice in one transaction adds nothing.
- **Only player docs that still exist get updated.** `transaction.update()` on a deleted doc fails the entire transaction, and `leaveTable` does delete docs — so the old `playersSnap.docs.forEach` would have been a latent failure once inside a transaction.
- Lint lands at **133, one below** the 134 baseline: replacing the `Record<string, any>` stats accumulator with a typed `Map` of snapshots removed a pre-existing `no-explicit-any`.

## The sweeper had the identical race

`scripts/end-stale-tables.mjs` selects `IN_GAME` tables in its outer query, but a host can close one before the write lands — same double-increment, server-side. Made transactional in the same commit, per the change-one-change-the-other rule.

Three behavioural differences from the client, each deliberate:

- It **skips rather than throws** when it loses the race. It's a batch job; one table closing under it shouldn't abort the whole sweep.
- It **reads its player query inside the transaction**, because `firebase-admin` permits queries in transactions where the Web SDK does not. This is the one intentional divergence between the two implementations, and it's noted in CLAUDE.md.
- Both log lines **moved outside the transaction body**, which re-runs on contention and would otherwise log the same table twice.

## Verification

The sweeper is the riskiest part here: it runs unattended on cron, there's no Firestore emulator configured, and the service-account key exists only as a CI secret — so it couldn't be run against anything real.

It now exports `endStaleTable` and only sweeps when invoked directly (`import.meta.url === pathToFileURL(process.argv[1]).href`), which let a harness drive **the real function** against a fake `db`. Not a copy of the logic — the actual exported function:

```
PASS  happy: outcome is 'ended'
PASS  happy: all reads precede all writes
PASS  happy: table set to SUMMARY
PASS  happy: playerIds recorded
PASS  happy: stats written only for the registered user
PASS  happy: sessionsPlayed incremented once
PASS  race: retried
PASS  race: outcome is 'already-ended'
PASS  race: no stats written on the retry
PASS  summary: outcome is 'already-ended'
PASS  summary: no writes at all
PASS  vanished: outcome is 'vanished'
PASS  vanished: no writes
14/14 passed
```

The two that matter are **"all reads precede all writes"** (violating that throws at runtime inside a Firestore transaction, and it's the failure mode this codebase warns about most) and **"no stats written on the retry"** — the actual bug.

- `npx tsc -b` — clean, exit 0.
- `npx eslint .` — 133, one below baseline.
- `node --check scripts/end-stale-tables.mjs` — OK.

The harness lives in scratch, not the repo, since there's no test runner to hang it off.

Manual checks worth doing against a throwaway table:

1. Host ends a game normally → recap written, `sessionsPlayed` +1 exactly once per player.
2. Two browser tabs as the same host, both clicking End Game → one succeeds, the other reports "this game has already ended", and stats increment **once**.
3. `cd scripts && DRY_RUN=1 npm run end-stale-tables` → still reports what it would do and writes nothing.
4. Sweeper against a genuinely stale table → recap identical in shape to the client's, with `endedByAutoSweep: true`.

## Note

CLAUDE.md's "Known exceptions" entry for `endGame` is rewritten. It no longer describes an exception — `endGame` is now the worked example of *why* the read-before-write discipline exists, since it's the case where a correct-looking guard was defeated by an unguarded read.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
