### PR TITLE
perf: split vendor bundles so a deploy doesn't re-download all of firebase

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -248,6 +248,14 @@ for hours with a wake lock held and would otherwise never see a deploy. `firebas
 `index.html` and `/sw.js` are `no-store`, hashed assets are immutable-cached. Don't add long-lived
 cache headers to those two.
 
+`vite.config.ts` splits vendors into `vendor-firestore` / `vendor-firebase` / `vendor-react` /
+`vendor-i18n` via `manualChunks`, which is a **caching** decision rather than a payload one: every
+chunk is needed to boot, so a cold load moves the same bytes either way. What it buys is that an
+ordinary deploy only re-hashes the app chunk (~158 kB gzip) instead of one ~363 kB blob, and with a
+15-minute update poll that difference lands often. If you add a vendor group, check the generated
+chunks' cross-imports stay **acyclic** — circular chunk dependencies are what turn a clean
+`vite build` into a "cannot access before initialization" at runtime.
+
 ### Ignore these
 
 `dataconnect/` and `frontend/src/dataconnect-generated/` are gitignored and unused — nothing imports

--- a/frontend/src/routes/HomePage.tsx
+++ b/frontend/src/routes/HomePage.tsx
@@ -76,26 +76,28 @@ export default function HomePage() {
     const cachedId = localStorage.getItem("activeTableId");
     if (!cachedId) return;
 
-    // Verify the table is still in a joinable state before showing the banner
-    import("../lib/firebase").then(({ db }) => {
-      import("firebase/firestore").then(({ doc, getDoc }) => {
-        getDoc(doc(db, "tables", cachedId)).then((snap) => {
-          if (!snap.exists()) {
-            localStorage.removeItem("activeTableId");
-            return;
-          }
-          const state = snap.data()?.state;
-          if (state === "SUMMARY" || state === "ENDED") {
-            localStorage.removeItem("activeTableId");
-          } else {
-            setActiveTableId(cachedId);
-          }
-        }).catch(() => {
-          // On network issue or error, still show the banner
+    // Verify the table is still in a joinable state before showing the banner.
+    // `db`, `doc` and `getDoc` are already static imports at the top of this file, so
+    // the nested dynamic imports this replaced split nothing out — they only produced
+    // the "dynamically imported by ... but also statically imported by ..." build
+    // warnings and an extra layer of callbacks.
+    getDoc(doc(db, "tables", cachedId))
+      .then((snap) => {
+        if (!snap.exists()) {
+          localStorage.removeItem("activeTableId");
+          return;
+        }
+        const state = snap.data()?.state;
+        if (state === "SUMMARY" || state === "ENDED") {
+          localStorage.removeItem("activeTableId");
+        } else {
           setActiveTableId(cachedId);
-        });
+        }
+      })
+      .catch(() => {
+        // On network issue or error, still show the banner
+        setActiveTableId(cachedId);
       });
-    });
   }, []);
 
   // Main Dashboard Data States

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -3,6 +3,29 @@ import react from '@vitejs/plugin-react'
 import { VitePWA } from 'vite-plugin-pwa'
 
 export default defineConfig({
+  // Everything below is about CACHING, not about shrinking the first load: these
+  // chunks are all needed to boot, so a cold visit downloads the same bytes either
+  // way. What changes is what a *returning* visitor re-downloads after a deploy.
+  // Previously app code and all of firebase/react/i18n lived in one ~1.1 MB hashed
+  // file, so editing a single line invalidated the whole thing. Split out, a normal
+  // deploy only invalidates the app chunk; the vendor chunks keep their hash and stay
+  // in cache. That matters here because firebase.json marks hashed assets
+  // immutable-cached, and ReloadPrompt.tsx polls for new deploys every 15 minutes —
+  // installed sessions pick up releases often, and each one paid full price before.
+  build: {
+    rollupOptions: {
+      output: {
+        manualChunks: {
+          // Firestore is by far the largest single dependency and the one whose
+          // version moves least often.
+          'vendor-firestore': ['firebase/firestore'],
+          'vendor-firebase': ['firebase/app', 'firebase/auth'],
+          'vendor-react': ['react', 'react-dom', 'react-router-dom'],
+          'vendor-i18n': ['i18next', 'react-i18next', 'i18next-browser-languagedetector'],
+        },
+      },
+    },
+  },
   server: {
     host: true,
     port: 5173,


### PR DESCRIPTION
## Summary

The build has warned about a 1.1 MB chunk on every run. App code, firebase, react and i18n all landed in **one hashed file**, so changing a single line of app code invalidated the whole 363 kB gzip and every returning visitor re-downloaded all of it.

Split into `vendor-firestore` / `vendor-firebase` / `vendor-react` / `vendor-i18n`.

## Read the numbers as a caching win, not a payload one

Every chunk is needed to boot, so **a cold load is unchanged** — 363.24 → 362.13 kB gzip, which is noise. I'd rather say that plainly than present a split as a size reduction.

What changes is the **deploy delta**. An app-code-only release now re-hashes just the app chunk:

| | before | after |
|---|---|---|
| `index` (app) | 1142.24 kB / **363.24** gzip | 466.91 kB / **158.06** gzip |
| `vendor-firestore` | — | 448.80 kB / 132.87 gzip |
| `vendor-firebase` | — | 107.94 kB / 32.17 gzip |
| `vendor-i18n` | — | 65.32 kB / 21.90 gzip |
| `vendor-react` | — | 48.41 kB / 17.13 gzip |

**363.24 → 158.06 kB gzip per deploy, ~56% less.** That matters here specifically because `ReloadPrompt.tsx` polls for new deploys every 15 minutes and `firebase.json` marks hashed assets immutable-cached — installed sessions take that hit often, and the vendor chunks now keep their hash across releases.

## Also removes two dead dynamic imports

`HomePage` did:

```ts
import("../lib/firebase").then(({ db }) => {
  import("firebase/firestore").then(({ doc, getDoc }) => { … })
})
```

`db`, `doc` and `getDoc` are **already static imports at the top of that same file** — which is exactly what the *"dynamically imported by … but also statically imported by …"* warnings were reporting. They split nothing out and only added a layer of nested callbacks.

The build is now **warning-free**: both dynamic-import warnings and the >500 kB chunk warning are gone.

## Verification

- `npx tsc -b` — clean, exit 0.
- `npx eslint .` — 134, the documented baseline.
- Production build served through `vite preview`: `index.html` and **all five chunks** return 200 with the expected byte counts, and the HTML preloads all five.
- **Cross-chunk import graph is acyclic** — this is the check that matters, since circular chunk dependencies are the specific way `manualChunks` turns a clean `vite build` into a runtime *"cannot access before initialization"*:

```
index            -> vendor-firebase, vendor-firestore, vendor-i18n, vendor-react
vendor-firestore -> vendor-firebase
vendor-i18n      -> vendor-react
vendor-firebase  -> (none)
vendor-react     -> (none)
```

`firebase` and `react` have no outgoing edges, so initialization order is well-defined.

**What I could not verify:** I did not boot this in a real browser — playwright resolves via `npx` here but no browsers are installed locally, and pulling ~300 MB for one page load wasn't a good trade. The structural check above targets the actual failure mode, but **the preview channel on this PR is the check that matters before merge**: load it, confirm the app renders and you can sign in. If module init were broken it would fail immediately and visibly, not subtly.

## Note

`CLAUDE.md`'s PWA section gains a short note on why the split exists and the acyclic constraint to preserve if a vendor group is ever added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
