### PR TITLE
fix: gate the finished-game recap, and stop inventing stats for new accounts

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,7 +20,7 @@ npm run lint       # eslint flat config (typescript-eslint + react-hooks + react
 into a Firebase init error.
 
 `npx tsc -b` is the real gate and passes clean; **`npm run lint` does not** — `main` currently
-carries ~134 pre-existing errors (122 of them `@typescript-eslint/no-explicit-any`, since Firestore
+carries 133 pre-existing errors (121 of them `@typescript-eslint/no-explicit-any`, since Firestore
 snapshot data is read as `any` throughout). Nothing in CI runs it. Compare against the baseline
 rather than treating a non-zero exit as your own regression.
 
@@ -202,6 +202,14 @@ itself is computed in `components/AdvancedStats.tsx`. It is divided by `vpipElig
 deliberately, **not** by `handsPlayed`/`stagePreflopCount`, because those accumulated before VPIP
 tracking existed and would skew the ratio for months. Keep new ratio metrics on their own
 matched-baseline denominators, and increment them where the event actually happens.
+
+**Never substitute a simulated value for a missing one.** `AdvancedStats.tsx` used to fall back to
+numbers derived from `winRate` whenever a counter was still zero, which on a fresh account evaluated
+to the constants VPIP 22% / aggression 35% — and those two then classified the player as "LAG" and
+plotted a marker on the radar. Playtime had the same problem (`sessionsPlayed * 0.8` rendered as
+measured hours). A metric with no data now renders as `—` and the style verdict is withheld until
+*both* axes are real, because a fabricated number is indistinguishable from a measured one once it
+reaches the screen.
 
 ### Auth
 

--- a/frontend/src/components/AdvancedStats.tsx
+++ b/frontend/src/components/AdvancedStats.tsx
@@ -35,56 +35,64 @@ export default function AdvancedStats({ stats }: AdvancedStatsProps) {
 
   const totalHands = stats.handsPlayed || 0;
   const winRate = totalHands > 0 ? Math.round((stats.handsWon / totalHands) * 100) : 0;
-  
-  // VPIP (Tight vs Loose) simulation/calculation
-  const sessions = stats.sessionsPlayed || 1;
-  const estimatedVpip = Math.max(12, Math.min(75, Math.round(22 + (winRate > 0 ? (winRate - 30) * 0.25 : 0))));
+
+  // Every metric below is shown only when its own counter has actually recorded
+  // something. These used to fall back to a "simulated" value derived from winRate,
+  // which for an account that had never played evaluated to a constant — VPIP 22%,
+  // aggression 35% — and those two constants then classified the player as "LAG" on
+  // the radar. A profile that has never played a hand must read as empty, not as an
+  // average player: invented numbers here are indistinguishable from measured ones.
+  const NO_DATA = "—";
+
   // vpipEligibleHands (not handsPlayed/stagePreflopCount) is the right denominator
   // and "do we have real data" signal. handsPlayed/stagePreflopCount have been
   // accumulating since long before vpipCount tracking was fixed, so dividing
   // vpipCount by either of them would produce an artificially low ratio for
   // months until enough new hands dilute out the pre-fix history.
   // vpipEligibleHands started at the same zero baseline as vpipCount, so their
-  // ratio is meaningful immediately, and a genuine 0% VPIP player isn't wrongly
-  // shown a simulated value just because vpipCount itself happens to be 0.
-  const hasRealVpipData = (stats.vpipEligibleHands || 0) > 0;
-  const vpip = hasRealVpipData
+  // ratio is meaningful immediately, and a genuine 0% VPIP player is a real 0%.
+  const hasVpipData = (stats.vpipEligibleHands || 0) > 0;
+  const vpip = hasVpipData
     ? Math.round(((stats.vpipCount || 0) / stats.vpipEligibleHands!) * 100)
-    : estimatedVpip;
+    : null;
 
   // Aggression Frequency (Aggressive vs Passive)
   const totalActions = stats.totalActions || 0;
   const aggActions = stats.aggressiveActions || 0;
-  const aggFreq = totalActions > 0
-    ? Math.round((aggActions / totalActions) * 100)
-    : Math.max(10, Math.min(85, Math.round(35 + (winRate > 0 ? (winRate - 30) * 0.35 : 0))));
+  const hasAggData = totalActions > 0;
+  const aggFreq = hasAggData ? Math.round((aggActions / totalActions) * 100) : null;
 
-  // Determine active profile type
-  const isLoose = vpip >= 22;
-  const isAggressive = aggFreq >= 35;
+  // The style verdict needs BOTH axes — one alone places the marker on a guess.
+  const hasStyleData = vpip !== null && aggFreq !== null;
 
-  const playerType = isLoose 
-    ? (isAggressive ? "LAG" : "FISH") 
-    : (isAggressive ? "TAG" : "ROCK");
+  const isLoose = (vpip ?? 0) >= 22;
+  const isAggressive = (aggFreq ?? 0) >= 35;
 
-  const playerTypeDesc = isLoose 
-    ? (isAggressive ? t("stats.styleLAGDesc") : t("stats.styleFISHDesc")) 
-    : (isAggressive ? t("stats.styleTAGDesc") : t("stats.styleROCKDesc"));
+  const playerType = hasStyleData
+    ? (isLoose ? (isAggressive ? "LAG" : "FISH") : (isAggressive ? "TAG" : "ROCK"))
+    : null;
+
+  const playerTypeDesc = hasStyleData
+    ? (isLoose
+        ? (isAggressive ? t("stats.styleLAGDesc") : t("stats.styleFISHDesc"))
+        : (isAggressive ? t("stats.styleTAGDesc") : t("stats.styleROCKDesc")))
+    : t("stats.noStyleDataDesc");
 
   // Calculate Marker Coordinate in 200x200 SVG Viewport
   // Center is (100, 100)
   // X axis: Tight (left, X=30) to Loose (right, X=170) -> map VPIP 10% to 50%
-  const xOffset = ((vpip - 22) / 20) * 55;
+  const xOffset = (((vpip ?? 22) - 22) / 20) * 55;
   const markerX = Math.max(30, Math.min(170, 100 + xOffset));
 
   // Y axis: Aggressive (top, Y=30) to Passive (bottom, Y=170) -> map aggFreq 15% to 55%
-  const yOffset = ((aggFreq - 35) / 20) * 55;
+  const yOffset = (((aggFreq ?? 35) - 35) / 20) * 55;
   const markerY = Math.max(30, Math.min(170, 100 - yOffset));
 
-  // Calculate actual time in hours, falling back on session-based estimate if not populated yet
+  // Real seconds or nothing. The old fallback multiplied sessionsPlayed by an
+  // invented 0.8h-per-session and rendered the product as measured playtime.
   const timePlayedHours = stats.timePlayedSeconds !== undefined
     ? (stats.timePlayedSeconds / 3600).toFixed(1)
-    : (sessions * 0.8).toFixed(1);
+    : null;
 
   return (
     <div className="stats-detailed-container" style={{ display: "flex", flexDirection: "column", gap: "1rem", marginTop: "1rem", width: "100%" }} id="advanced-stats-root">
@@ -95,7 +103,7 @@ export default function AdvancedStats({ stats }: AdvancedStatsProps) {
           {t("stats.playerStyle") || "Stile di Gioco"}
         </span>
         <h2 className="radar-chart-title" style={{ marginTop: "0.2rem", fontSize: "1.8rem", fontWeight: 800 }}>
-          {playerType}
+          {playerType ?? NO_DATA}
         </h2>
         <p className="radar-chart-subtitle" style={{ fontSize: "0.85rem", color: "var(--text-muted)", marginTop: "0.3rem", lineHeight: 1.4 }}>
           {playerTypeDesc}
@@ -134,23 +142,28 @@ export default function AdvancedStats({ stats }: AdvancedStatsProps) {
               {t("stats.axisTight") || "TIGHT"}
             </text>
 
-            {/* Dynamic Player Shape */}
-            <polygon 
-              points={`100,${Math.min(100, markerY)} ${Math.max(100, markerX)},100 100,${Math.max(100, markerY)} ${Math.min(100, markerX)},100`} 
-              fill="rgba(59, 130, 246, 0.15)" 
-              stroke="var(--color-primary)" 
-              strokeWidth="1.5" 
-            />
+            {/* Dynamic Player Shape — only once both axes are measured. Plotting a
+                marker without data would put a confident dot on a guessed position. */}
+            {hasStyleData && (
+              <>
+                <polygon
+                  points={`100,${Math.min(100, markerY)} ${Math.max(100, markerX)},100 100,${Math.max(100, markerY)} ${Math.min(100, markerX)},100`}
+                  fill="rgba(59, 130, 246, 0.15)"
+                  stroke="var(--color-primary)"
+                  strokeWidth="1.5"
+                />
 
-            {/* Active Position Indicator */}
-            <defs>
-              <radialGradient id="markerGlow" cx="50%" cy="50%" r="50%">
-                <stop offset="0%" stopColor="var(--color-primary)" stopOpacity="1" />
-                <stop offset="100%" stopColor="var(--color-primary)" stopOpacity="0" />
-              </radialGradient>
-            </defs>
-            <circle cx={markerX} cy={markerY} r="10" fill="url(#markerGlow)" />
-            <circle cx={markerX} cy={markerY} r="4" fill="#fff" stroke="var(--color-primary)" strokeWidth="2" />
+                {/* Active Position Indicator */}
+                <defs>
+                  <radialGradient id="markerGlow" cx="50%" cy="50%" r="50%">
+                    <stop offset="0%" stopColor="var(--color-primary)" stopOpacity="1" />
+                    <stop offset="100%" stopColor="var(--color-primary)" stopOpacity="0" />
+                  </radialGradient>
+                </defs>
+                <circle cx={markerX} cy={markerY} r="10" fill="url(#markerGlow)" />
+                <circle cx={markerX} cy={markerY} r="4" fill="#fff" stroke="var(--color-primary)" strokeWidth="2" />
+              </>
+            )}
           </svg>
         </div>
       </div>
@@ -166,7 +179,9 @@ export default function AdvancedStats({ stats }: AdvancedStatsProps) {
             </div>
             <span className="stats-detailed-label">{t("stats.aggressionFreq") || "Aggression freq."}</span>
           </div>
-          <span className="stats-detailed-value" style={{ fontWeight: 800 }}>{aggFreq}%</span>
+          <span className="stats-detailed-value" style={{ fontWeight: 800 }}>
+            {aggFreq === null ? NO_DATA : `${aggFreq}%`}
+          </span>
         </div>
 
         {/* Time Played */}
@@ -177,7 +192,9 @@ export default function AdvancedStats({ stats }: AdvancedStatsProps) {
             </div>
             <span className="stats-detailed-label">{t("stats.timePlayed") || "Tempo di gioco"}</span>
           </div>
-          <span className="stats-detailed-value" style={{ fontWeight: 800 }}>{timePlayedHours}h</span>
+          <span className="stats-detailed-value" style={{ fontWeight: 800 }}>
+            {timePlayedHours === null ? NO_DATA : `${timePlayedHours}h`}
+          </span>
         </div>
 
         {/* Street Frequencies */}

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -145,6 +145,8 @@
     "invested": "Invested",
     "finalStack": "Final",
     "backHome": "Back to home",
+    "summaryNotParticipantTitle": "Game already finished",
+    "summaryNotParticipantDesc": "This table's game has ended. Only the players who took part can view the recap.",
     "lobbyPlayersCount": "Players: {{count}}",
     "leaveLobby": "Leave table",
     "blindsShort": "Blinds:",
@@ -424,6 +426,7 @@
     "styleTAGDesc": "Plays few hands in a highly aggressive manner (Tight-Aggressive).",
     "styleLAGDesc": "Plays many hands in a highly aggressive manner (Loose-Aggressive).",
     "styleROCKDesc": "Plays very few hands in a passive manner (Tight-Passive).",
+    "noStyleDataDesc": "Play a few hands to see your playing style.",
     "styleFISHDesc": "Plays too many hands in a passive manner (Loose-Passive)."
   }
 }

--- a/frontend/src/locales/it.json
+++ b/frontend/src/locales/it.json
@@ -145,6 +145,8 @@
     "invested": "Investito",
     "finalStack": "Finale",
     "backHome": "Torna alla home",
+    "summaryNotParticipantTitle": "Partita già terminata",
+    "summaryNotParticipantDesc": "La partita di questo tavolo è finita. Solo i giocatori che vi hanno partecipato possono vederne il riepilogo.",
     "lobbyPlayersCount": "Giocatori: {{count}}",
     "leaveLobby": "Esci dal tavolo",
     "blindsShort": "Bui:",
@@ -424,6 +426,7 @@
     "styleTAGDesc": "Gioca poche mani in modo molto aggressivo (Tight-Aggressive).",
     "styleLAGDesc": "Gioca molte mani in modo molto aggressivo (Loose-Aggressive).",
     "styleROCKDesc": "Gioca pochissime mani in modo passivo (Tight-Passive).",
+    "noStyleDataDesc": "Gioca qualche mano per scoprire il tuo stile di gioco.",
     "styleFISHDesc": "Gioca troppe mani in modo passivo (Loose-Passive)."
   }
 }

--- a/frontend/src/routes/PlayerProfilePage.tsx
+++ b/frontend/src/routes/PlayerProfilePage.tsx
@@ -47,6 +47,7 @@ export default function PlayerProfilePage() {
 
   const [targetUser, setTargetUser] = useState<TargetUser | null>(null);
   const [targetUserPresence, setTargetUserPresence] = useState<any>(null);
+  const [targetTableState, setTargetTableState] = useState<string | null>(null);
   const [friendStatus, setFriendStatus] = useState<"NONE" | "PENDING_SENT" | "PENDING_RECEIVED" | "ACCEPTED" | "SELF">("NONE");
   const [loading, setLoading] = useState(true);
   const [errorMsg, setErrorMsg] = useState<string | null>(null);
@@ -123,7 +124,27 @@ export default function PlayerProfilePage() {
     return () => {
       if (unsubPresence) unsubPresence();
     };
+
   }, [targetUsername, user]);
+
+  // Presence says the friend is AT a table, not that the table can be joined: someone
+  // sitting on the finished-game recap still reports location "TABLE" with a tableId.
+  // Track the table's own state so the join button reflects reality.
+  useEffect(() => {
+    const presenceTableId = targetUserPresence?.tableId;
+    if (!presenceTableId) {
+      setTargetTableState(null);
+      return;
+    }
+
+    const unsub = onSnapshot(
+      doc(db, "tables", presenceTableId),
+      (snap) => setTargetTableState(snap.exists() ? (snap.data().state ?? null) : null),
+      () => setTargetTableState(null)
+    );
+
+    return () => unsub();
+  }, [targetUserPresence?.tableId]);
 
   // Listen to friend status
   useEffect(() => {
@@ -335,7 +356,9 @@ export default function PlayerProfilePage() {
         {friendStatus === "ACCEPTED" &&
          targetUserPresence?.status === "ONLINE" &&
          targetUserPresence?.location === "TABLE" &&
-         targetUserPresence?.tableId && (
+         targetUserPresence?.tableId &&
+         // Mirrors joinTable()'s own guard — anything else (SUMMARY) is not joinable.
+         (targetTableState === "LOBBY" || targetTableState === "IN_GAME") && (
            <button
              id="btn-player-profile-join-table"
              onClick={() => navigate(`/table/${targetUserPresence.tableId}`)}

--- a/frontend/src/routes/TablePage.tsx
+++ b/frontend/src/routes/TablePage.tsx
@@ -1033,6 +1033,30 @@ export default function TablePage() {
     ? players.find((p) => p.userId === myUid) || null
     : null;
 
+  // A finished table's recap lists every player's final stack and net profit, so it
+  // is only for the people who were actually at that table. Nothing else gated this:
+  // joinTable() refuses a SUMMARY table and auto-join skips one, but neither runs on
+  // this path — the friend-profile "join" button and any shared link navigate straight
+  // here, and presence saying location === "TABLE" does not mean the viewer ever played.
+  // playersLoaded is required so a genuine participant isn't bounced while the players
+  // subcollection is still on its first fetch.
+  if (inSummary && playersLoaded && !myPlayer) {
+    return (
+      <div style={fullScreenContainerStyle}>
+        <div className="glass-panel" style={panelContainerStyle}>
+          <div style={{ color: "#f59e0b" }}><ShieldAlert size={44} /></div>
+          <div>
+            <h3 style={titleStyle}>{t("table.summaryNotParticipantTitle")}</h3>
+            <p style={descStyle}>{t("table.summaryNotParticipantDesc")}</p>
+          </div>
+          <button onClick={() => navigate("/home")} className="poker-btn-primary" style={btnStyle}>
+            {t("table.backHome")}
+          </button>
+        </div>
+      </div>
+    );
+  }
+
 
   const isMyTurn =
     inGame &&


### PR DESCRIPTION
Fixes two of the three reported bugs. The third (real-time sync) is still under investigation and is **not** in this PR — findings at the bottom.

---

## 1. A friend's "join table" button could open a finished game

The button gated purely on **presence** — `status: ONLINE`, `location: "TABLE"`, a `tableId`. But presence says *where someone is*, not whether that table can be joined: a player sitting on the SUMMARY recap still reports `location: "TABLE"`. It then navigated straight to `/table/:id`.

Tracing it, the seating was already safe — `joinTable()` refuses anything but `LOBBY`/`IN_GAME`, and TablePage's auto-join explicitly skips `SUMMARY`. **Nobody was ever actually seated.**

What was missing is a viewer check on the recap itself:

```tsx
{inSummary && renderSummary()}
```

That rendered **every player's final stack and net profit** to whoever opened the URL. That's the real defect — it's a privacy leak rather than a join bug, and it's reachable by shared link, not just the button. So it's fixed at the render site, not only at the entry point:

- **`TablePage`** shows a "you weren't in this game" panel unless the viewer has a player doc at that table. Gated on `playersLoaded` so a genuine participant isn't bounced while the players subcollection is still on its first fetch.
- **`PlayerProfilePage`** additionally subscribes to the table's own `state` and only offers the button for `LOBBY` or `IN_GAME`, mirroring `joinTable()`'s guard.

## 2. A brand-new account showed "Aggression freq. 35%"

Not a rounding artifact — a **fabricated value**. `AdvancedStats` fell back to numbers derived from `winRate` whenever a counter was still zero:

```js
const aggFreq = totalActions > 0
  ? Math.round((aggActions / totalActions) * 100)
  : Math.max(10, Math.min(85, Math.round(35 + (winRate > 0 ? (winRate - 30) * 0.35 : 0))));
```

With no hands played `winRate` is 0, so the fallback reduces to `Math.round(35 + 0)` — **exactly 35, every time**. VPIP had the same shape and produced 22.

It didn't stop at two numbers. Those constants satisfy `isLoose` (≥22) and `isAggressive` (≥35), so an account that had **never played a hand** was labelled **"LAG"** with a marker plotted on the radar chart. Playtime did it too, rendering `sessionsPlayed * 0.8` as measured hours.

Each metric now renders only when its own counter has recorded something, otherwise `—`, and the style verdict and radar marker are withheld until **both** axes are real. The counters themselves were always written correctly in `playerAction` — only the display invented data.

## Test plan

- `npx tsc -b` — clean, exit 0.
- `npx eslint .` — 133, the baseline.
- Locale parity 390/390 (three keys added to each).

Manual checks:

1. Friend on a `SUMMARY` table → no join button on their profile. Friend in a `LOBBY`/`IN_GAME` table → button still there and still works.
2. Open a finished table's URL directly as a non-participant → "you weren't in this game", no recap. As a participant → recap renders exactly as before.
3. Brand-new account's stats page → aggression, VPIP and playtime show `—`, style shows `—` with "play a few hands…", no radar marker.
4. An account with real history → all values unchanged from before.

## Note

Also corrects CLAUDE.md's lint baseline to **133 / 121 `no-explicit-any`** (verified by count), which the `endGame` typed `Map` moved in #17 — I said I'd fold it into the next PR touching that file rather than spend a PR on it.

---

## On bug 3 (real-time sync) — not fixed here

I investigated and want to report honestly rather than ship a guess.

**Ruled out:** the listeners are structurally correct. `onSnapshot` on the table, the players query and the current hand all have stable dep arrays, clean unsubscribes, and error handlers. There's already a `visibilitychange` → `refreshKey` re-subscribe, so backgrounding is handled — and your symptom happens on a *visible* tab, which that can't explain. `experimentalForceLongPolling: true` is already set in `firebase.ts`, so my leading hypothesis (WebChannel silently blocked by a proxy/carrier) is wrong too.

**What that leaves:** the subscriptions are live but the transport stalls without the SDK surfacing it. The app has no way to know — and neither does the user, which is why reloading feels like the only option.

**Proposed direction:** `onSnapshot` exposes `snapshot.metadata.fromCache`. A listener that is connected delivers `fromCache: false`; one whose stream has died keeps serving cache. That's a real signal we currently ignore, and it turns a silent failure into a detectable one — show a "reconnecting" indicator so the screen is never silently trusted, and optionally self-heal via `disableNetwork()` / `enableNetwork()`.

I'd rather agree that approach with you before building it, since it adds visible UI and the root cause is still unconfirmed. One question that would narrow it a lot: when it happens, is it **one specific client** stuck while others update fine, or **everyone at once**?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
